### PR TITLE
Switch the client instead of attaching the session if already in tmux

### DIFF
--- a/lib/tmuxinator/assets/tmux_config.tmux
+++ b/lib/tmuxinator/assets/tmux_config.tmux
@@ -20,4 +20,8 @@ tmux select-window -t <%= @project_name %>:1
 
 fi
 
-tmux -u attach-session -t <%= @project_name %>
+if [ -z $TMUX ]; then
+    tmux -u attach-session -t <%= @project_name %>
+else
+    tmux -u switch-client -t <%= @project_name %>
+fi


### PR DESCRIPTION
If $TMUX is set, then I'm already in a session and it's better to switch the client than nesting the new session.
