### PR TITLE
Resolution for #6

### DIFF
--- a/lib/tmuxinator/assets/tmux_config.tmux
+++ b/lib/tmuxinator/assets/tmux_config.tmux
@@ -1,10 +1,10 @@
 #!<%= ENV['SHELL'] || '/bin/bash' %>
-cd <%=s @project_root %>
 tmux start-server
 
 if ! $(tmux has-session -t <%=s @project_name %>); then
 
 tmux new-session -d -s <%=s @project_name %> -n <%=s @tabs[0].name %>
+tmux set default-path <%= @project_root %>
 tmux set-option base-index 1
 
 <% @tabs[1..-1].each_with_index do |tab, i| %>


### PR DESCRIPTION
This patch does away with the cd PROJECT method of setting a root path and instead uses the tmux default-path variable.
