### PR TITLE
command line completion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ That will auto-complete `tmuxinator` commands, plus your `.yml` config files.
 
 It will also add a couple of aliases to your environment:
 
-* `tx`: for commands.
-* `txo`: for `opening` your `.yml` configs.
+* `mux` or `tmuxinator` + Tab: for commands.
+* `muxo` + Tab: for `.yml` configs.
 
 ## Usage
 

--- a/tmuxinator_completion
+++ b/tmuxinator_completion
@@ -25,8 +25,8 @@ _tmuxinator_open_complete()
   return 0
 }
 
-alias tx='tmuxinator'
-alias txo='tmuxinator open'
+alias mux='tmuxinator'
+alias muxo='tmuxinator open'
 
-complete -F _tmuxinator_commands_complete -o default tmuxinator tx
-complete -F _tmuxinator_open_complete -o default txo
+complete -F _tmuxinator_commands_complete -o default tmuxinator mux
+complete -F _tmuxinator_open_complete -o default muxo


### PR DESCRIPTION
Added command line completion for opening .yml configs and `tmuxinator` options.

The completion for commands could be a bit smarter if the `-h` option would have a bit more "predictable" output.

Check it out and merge it if it's okay with you :)

Cheers,
