### PR TITLE
Allow optional socket name

### DIFF
--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -3,6 +3,7 @@
 
 project_name: Tmuxinator
 project_root: ~/code/rails_project
+socket_name: foo # Not needed.  Remove to use default socket
 rvm: 1.9.2@rails_project
 pre: sudo /etc/rc.d/mysqld start
 tabs:

--- a/lib/tmuxinator/assets/tmux_config.tmux
+++ b/lib/tmuxinator/assets/tmux_config.tmux
@@ -1,14 +1,14 @@
 #!<%= ENV['SHELL'] || '/bin/bash' %>
-tmux start-server
+tmux <%= socket %> start-server
 
-if ! $(tmux has-session -t <%=s @project_name %>); then
+if ! $(tmux <%= socket %> has-session -t <%=s @project_name %>); then
 cd <%= @project_root || "." %>
 <%= @pre.kind_of?(Array) ? @pre.join(" && ") : @pre %>
-env TMUX= tmux start-server \; set-option -g base-index 1 \; new-session -d -s <%=s @project_name %> -n <%=s @tabs[0].name %>
-tmux set-option -t <%=s @project_name %> default-path <%= @project_root %>
+env TMUX= tmux <%= socket %> start-server \; set-option -g base-index 1 \; new-session -d -s <%=s @project_name %> -n <%=s @tabs[0].name %>
+tmux <%= socket %> set-option -t <%=s @project_name %> default-path <%= @project_root %>
 
 <% @tabs[1..-1].each_with_index do |tab, i| %>
-tmux new-window -t <%= window(i+2) %> -n <%=s tab.name %>
+tmux <%= socket %> new-window -t <%= window(i+2) %> -n <%=s tab.name %>
 <% end %>
 
 # set up tabs and panes
@@ -19,19 +19,19 @@ tmux new-window -t <%= window(i+2) %> -n <%=s tab.name %>
 <%   elsif tab.panes %>
 <%=    send_keys(tab.panes.shift, i+1) %>
 <%     tab.panes.each do |pane| %>
-tmux splitw -t <%= window(i+1) %>
+tmux <%= socket %> splitw -t <%= window(i+1) %>
 <%=      send_keys(pane, i+1) %>
 <%     end %>
-tmux select-layout -t <%= window(i+1) %> <%=s tab.layout %>
+tmux <%= socket %> select-layout -t <%= window(i+1) %> <%=s tab.layout %>
 <%   end %>
 <% end %>
 
-tmux select-window -t <%= window(1) %>
+tmux <%= socket %> select-window -t <%= window(1) %>
 
 fi
 
 if [ -z $TMUX ]; then
-    tmux -u attach-session -t <%=s @project_name %>
+    tmux <%= socket %> -u attach-session -t <%=s @project_name %>
 else
-    tmux -u switch-client -t <%=s @project_name %>
+    tmux <%= socket %> -u switch-client -t <%=s @project_name %>
 fi

--- a/lib/tmuxinator/config_writer.rb
+++ b/lib/tmuxinator/config_writer.rb
@@ -28,6 +28,10 @@ module Tmuxinator
       "#{root_dir}#{file_name}.tmux" if file_name
     end
 
+    def socket
+      "-L #{@socket_name}" if @socket_name
+    end
+
     private
 
     def root_dir
@@ -50,6 +54,7 @@ module Tmuxinator
       @rvm          = yaml["rvm"]
       @pre          = build_command(yaml["pre"])
       @tabs         = []
+      @socket_name  = yaml['socket_name']
 
       yaml["tabs"].each do |tab|
         t       = OpenStruct.new
@@ -83,7 +88,7 @@ module Tmuxinator
 
     def send_keys cmd, window_number
       return '' unless cmd
-      "tmux send-keys -t #{window(window_number)} #{s cmd} C-m"
+      "tmux #{socket} send-keys -t #{window(window_number)} #{s cmd} C-m"
     end
 
     def build_command(value)

--- a/spec/tmuxinator_spec.rb
+++ b/spec/tmuxinator_spec.rb
@@ -9,6 +9,7 @@ describe Tmuxinator::ConfigWriter do
     its(:tabs){ should be_nil }
     its(:config_path){ should be_nil }
     its(:pre){ should be_nil }
+    its(:socket){ should be_nil }
   end
 
   context "While Defining the filename on init" do
@@ -29,6 +30,7 @@ describe Tmuxinator::ConfigWriter do
     its(:rvm){ should eql '1.9.2@rails_project' }
     its(:tabs){ should be_an Array  }
     its(:pre){ should eql 'rvm use 1.9.2@rails_project && sudo /etc/rc.d/mysqld start' }
+    its(:socket){ should eql '-L foo' }
 
     let(:first_tab){ subject.tabs[0] }
 


### PR DESCRIPTION
Allows config file to specify an optional socket_name to be specified for use with the -L option.  If the socket_name is not specified, no -L option is used
