### PR TITLE
enable tmux settings for session 

### DIFF
--- a/lib/tmuxinator/assets/tmux_config.tmux
+++ b/lib/tmuxinator/assets/tmux_config.tmux
@@ -11,6 +11,10 @@ tmux <%= socket %> set-option -t <%=s @project_name %> default-path <%= @project
 tmux <%= socket %> set-option -t <%=s @project_name%> <%= setting %>
 <% end %>
 
+<% hotkeys.each do |hotkey| %>
+tmux <%= socket %> bind-key <%= hotkey %>
+<% end %>
+
 <% @tabs[1..-1].each_with_index do |tab, i| %>
 tmux <%= socket %> new-window -t <%= window(i+2) %> -n <%=s tab.name %>
 <% end %>

--- a/lib/tmuxinator/config_writer.rb
+++ b/lib/tmuxinator/config_writer.rb
@@ -1,7 +1,7 @@
 module Tmuxinator
 
   class ConfigWriter
-    attr_accessor :file_name, :file_path, :project_name, :project_root, :rvm, :tabs, :pre, :settings
+    attr_accessor :file_name, :file_path, :project_name, :project_root, :rvm, :tabs, :pre, :settings, :hotkeys
 
     include Tmuxinator::Helper
 
@@ -56,6 +56,7 @@ module Tmuxinator
       @tabs         = []
       @socket_name  = yaml['socket_name']
       @settings     = ensure_list(yaml['settings'])
+      @hotkeys     = ensure_list(yaml['hotkeys'])
 
       yaml["tabs"].each do |tab|
         t       = OpenStruct.new


### PR DESCRIPTION
I like tmuxinator, it helps me to manage tmux config easier.
I just add a new function that allow user to specify tmux settings in yml file. One use case is: user(like me) can specify different status-bg color based on session. 
