### PR TITLE
Update the sample so that the logs window actually opens the rails logs

### DIFF
--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -26,7 +26,7 @@ tabs:
         -
   - database: rails db
   - server: rails s
-  - logs: tail -f logs/development.log
+  - logs: tail -f log/development.log
   - console: rails c
   - capistrano:
   - server: ssh me@myhost


### PR DESCRIPTION
By default rails logs are in log/development.log not logs/development.log

This bites me everytime I create a new config, as I like most of the defaults, and forget to change that one.
