### PR TITLE
Set layout after adding each new pane

### DIFF
--- a/lib/tmuxinator/assets/tmux_config.tmux
+++ b/lib/tmuxinator/assets/tmux_config.tmux
@@ -30,8 +30,8 @@ tmux <%= socket %> new-window -t <%= window(i+2) %> -n <%=s tab.name %>
 tmux <%= socket %> splitw -t <%= window(i+1) %>
 <%=      send_keys(tab.pre, i+1) if tab.pre %>
 <%=      send_keys(pane, i+1) %>
-<%     end %>
 tmux <%= socket %> select-layout -t <%= window(i+1) %> <%=s tab.layout %>
+<%     end %>
 <%   end %>
 <% end %>
 


### PR DESCRIPTION
Especially when using tiled layout, creating more panes ends up with message:
"pane too small". For example:

```
tabs:
  - shells:
      layout: tiled
      panes:
        - echo 1
        - echo 2
        - echo 3
        - echo 4
        - echo 5
        - echo 6
```

It's because the layout is set after creating all the panes. Setting layout
after creating each pane fixes this issue.
