### PR TITLE
Removed hard-coded option setting base-index to 1

### DIFF
--- a/lib/tmuxinator/assets/tmux_config.tmux
+++ b/lib/tmuxinator/assets/tmux_config.tmux
@@ -4,7 +4,7 @@ tmux <%= socket %> start-server
 if ! $(tmux <%= socket %> has-session -t <%=s @project_name %>); then
 cd <%= @project_root || "." %>
 <%= @pre.kind_of?(Array) ? @pre.join(" && ") : @pre %>
-env TMUX= tmux <%= socket %> start-server \; set-option -g base-index 1 \; new-session -d -s <%=s @project_name %> -n <%=s @tabs[0].name %>
+env TMUX= tmux <%= socket %> start-server \; new-session -d -s <%=s @project_name %> -n <%=s @tabs[0].name %>
 tmux <%= socket %> set-option -t <%=s @project_name %> default-path <%= @project_root %>
 
 <% settings.each do |setting| %>


### PR DESCRIPTION
My windows start at 0, and I like that just fine; options like this should not be hard-coded, but should respect my ~/.tmux.conf settings.
