### PR TITLE
Remove base-index option when starting up the tmux server

### DIFF
--- a/lib/tmuxinator/assets/tmux_config.tmux
+++ b/lib/tmuxinator/assets/tmux_config.tmux
@@ -4,7 +4,7 @@ tmux <%= socket %> start-server
 if ! $(tmux <%= socket %> has-session -t <%=s @project_name %>); then
 cd <%= @project_root || "." %>
 <%= @pre.kind_of?(Array) ? @pre.join(" && ") : @pre %>
-env TMUX= tmux <%= socket %> start-server \; set-option -g base-index 1 \; new-session -d -s <%=s @project_name %> -n <%=s @tabs[0].name %>
+env TMUX= tmux <%= socket %> start-server \; new-session -d -s <%=s @project_name %> -n <%=s @tabs[0].name %>
 tmux <%= socket %> set-option -t <%=s @project_name %> default-path <%= @project_root %>
 
 <% settings.each do |setting| %>
@@ -16,26 +16,26 @@ tmux <%= socket %> bind-key <%= hotkey %>
 <% end %>
 
 <% @tabs[1..-1].each_with_index do |tab, i| %>
-tmux <%= socket %> new-window -t <%= window(i+2) %> -n <%=s tab.name %>
+tmux <%= socket %> new-window -n <%=s tab.name %>
 <% end %>
 
 # set up tabs and panes
-<% @tabs.each_with_index do |tab, i| %>
+<% @tabs.each do |tab| %>
 # tab "<%= tab.name %>"
 <%   if tab.command %>
-<%=    send_keys(tab.command, i+1) %>
+<%=    send_keys(tab.command, tab.name) %>
 <%   elsif tab.panes %>
-<%=    send_keys(tab.panes.shift, i+1) %>
+<%=    send_keys(tab.panes.shift, tab.name) %>
 <%     tab.panes.each do |pane| %>
-tmux <%= socket %> splitw -t <%= window(i+1) %>
-<%=      send_keys(tab.pre, i+1) if tab.pre %>
-<%=      send_keys(pane, i+1) %>
+tmux <%= socket %> splitw -t <%= window(tab.name) %>
+<%=      send_keys(tab.pre, tab.name) if tab.pre %>
+<%=      send_keys(pane, tab.name) %>
 <%     end %>
-tmux <%= socket %> select-layout -t <%= window(i+1) %> <%=s tab.layout %>
+tmux <%= socket %> select-layout -t <%= window(tab.name) %> <%=s tab.layout %>
 <%   end %>
 <% end %>
 
-tmux <%= socket %> select-window -t <%= window(1) %>
+tmux <%= socket %> select-window -t <%= window(@tabs[0].name) %>
 
 fi
 

--- a/lib/tmuxinator/config_writer.rb
+++ b/lib/tmuxinator/config_writer.rb
@@ -92,9 +92,9 @@ module Tmuxinator
       "#{s @project_name}:#{i}"
     end
 
-    def send_keys cmd, window_number
+    def send_keys cmd, window_id
       return '' unless cmd
-      "tmux #{socket} send-keys -t #{window(window_number)} #{s cmd} C-m"
+      "tmux #{socket} send-keys -t #{window(window_id)} #{s cmd} C-m"
     end
 
     def ensure_list(value)


### PR DESCRIPTION
so that users can use their base-index settings in tmux.conf.
