### PR TITLE
Focus on first pane of each tab

### DIFF
--- a/lib/tmuxinator/assets/tmux_config.tmux
+++ b/lib/tmuxinator/assets/tmux_config.tmux
@@ -21,6 +21,7 @@ tmux <%= socket %> new-window -t <%= window(i+1) %> -n <%=s tab.name %>
 <%     tab.panes.each do |pane| %>
 tmux <%= socket %> splitw -t <%= window(i) %>
 <%=      send_keys(pane, i) %>
+tmux <%= socket %> select-pane -t <%= window(i) %>.0
 <%     end %>
 tmux <%= socket %> select-layout -t <%= window(i) %> <%=s tab.layout %>
 <%   end %>


### PR DESCRIPTION
This is in reference to #74 and #52

We can focus on the first pane by default.
