### PR TITLE
Optionally persist per-shell history across tmux sessions

### DIFF
--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -4,6 +4,7 @@
 project_name: Tmuxinator
 project_root: ~/code/rails_project
 socket_name: foo # Not needed.  Remove to use default socket
+save_history: true # Persist history for each pane
 rvm: 1.9.2@rails_project
 pre: sudo /etc/rc.d/mysqld start
 cli_args: -v -2

--- a/lib/tmuxinator/config_writer.rb
+++ b/lib/tmuxinator/config_writer.rb
@@ -56,6 +56,7 @@ module Tmuxinator
       @project_root = yaml["project_root"]
       @rvm          = yaml["rvm"]
       @pre          = build_command(yaml["pre"])
+      @save_history = yaml["save_history"]
       @tabs         = []
       @socket_name  = yaml['socket_name']
       @socket_path  = yaml['socket_path']
@@ -92,6 +93,11 @@ module Tmuxinator
       "'#{str.to_s.gsub("'") { %('\'') }}'"
     end
     alias s shell_escape
+
+    def shell_remove_quote_escape str
+      "\"#{str.to_s.gsub(/["'`:]/, "")}\""
+    end
+    alias S shell_remove_quote_escape
 
     def window(i)
       "#{s @project_name}:#{i}"


### PR DESCRIPTION
Adds a new configuration option "save_history", which enables storing per-shell history in root_dir.

This is accomplished by setting HISTFILE to special values in tmux_config.mux. When possible, filenames are taken from tab names. New shells created in the tmux session will use the standard history file (.bash_history by default), since I don't think tmuxinator can affect those shells.

I've tested on bash; it should work on zsh. Presumably, though, zsh users will be less interested, since it supports shared history far better than bash.

Input on style/correctness welcome.
