### PR TITLE
Support configfile in current directory. 

### DIFF
--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -8,7 +8,7 @@ module Tmuxinator
 
       def run *args
         if args.empty?
-          self.usage
+          self.send('tmuxinator', *args)
         else
           self.send(args.shift, *args)
         end
@@ -142,7 +142,8 @@ module Tmuxinator
         exit!("You must specify a name for the new project") unless args.size > 0
         puts "warning: passing multiple arguments to open will be ignored" if args.size > 1
         project_name = args.shift
-        config_path = "#{root_dir}#{project_name}.yml"
+        config_path = "#{Dir.pwd}/#{project_name}.yml"
+        config_path = "#{root_dir}#{project_name}.yml" unless File.exists?(config_path)
         config = Tmuxinator::ConfigWriter.new(config_path).render
         # replace current proccess by running compiled tmux config
         exec(config)
@@ -150,7 +151,7 @@ module Tmuxinator
       alias :s :start
 
       def method_missing method, *args, &block
-        start method if File.exists?("#{root_dir}#{method}.yml")
+        start method if (File.exists?("#{root_dir}#{method}.yml") or File.exists?("#{Dir.pwd}/#{method}.yml"))
         puts "There's no command or project '#{method}' in tmuxinator"
         usage
       end


### PR DESCRIPTION
Been using tmuxinator for a little while, one feature I couldn't find anywhere
including current open issues was to be able to work from a configuration
file that I can store within my projects root. So, I had a look to see if that's
something I could add easily, and I could so I present it here for consideraton
as a feature to add to the master repo for tmuxinator. Hopefully I've sent this
through to you ok. If I can do anything else please let me know. Kind regards.

Working from the root of a Rails project, its tmuxinator configuration 
can be stored at that root, enabling it to be packaged with
the project's source tree. Starting tmux with no arguments
will launch the default 'tmuxinator.yml' from the current
directory if that exists. If a project name is given and
its file exists in the current directory it will be used
in preference to anything in ~/.tmuxinator.

Note: nothing has been done to facilitate writing configs
to the current directory: they can be created as normal
in ~/.tmuxinator and copied manually. Further editing can
always be done directly using vim.