### PR TITLE
tmuxinator_completion on OSX not completing on project *.yml names

### DIFF
--- a/bin/tmuxinator_completion
+++ b/bin/tmuxinator_completion
@@ -7,23 +7,27 @@ have=$(command -v tmuxinator)
 test -n "$have" &&
 _tmuxinator_commands_complete()
 {
+  local cur prev
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
   COMPREPLY=()
   if [ $COMP_CWORD = 1 ]; then
-    local commands="open copy delete update_scripts implode list doctor help version"
+    local commands="start open copy delete implode list doctor help version"
     COMPREPLY=(`compgen -W "$commands" -- $2`)
-  fi
-  return 0
-}
-
-_tmuxinator_open_complete()
-{
-  COMPREPLY=()
-  if [ $COMP_CWORD = 1 ]; then
-    local configs=`find ~/.tmuxinator/ -name *.yml | cut -d/ -f5 | sed s:.yml::g`
-    COMPREPLY=(`compgen -W "$configs" -- $2`)
+  else 
+  	case "${prev}" in
+  		# complete any action [project_config]
+  		start|open|copy|delete)
+			local configs=`find -L ~/.tmuxinator -name *.yml | cut -d/ -f5 | sed s:.yml::g`
+			COMPREPLY=(`compgen -W "$configs" -- $2`)
+			;;
+		list)
+			local listparams="-v"
+			COMPREPLY=(`compgen -W "$listparams" -- $2`)
+			;;
+	esac
   fi
   return 0
 }
 
 complete -F _tmuxinator_commands_complete -o default tmuxinator mux
-complete -F _tmuxinator_open_complete -o default muxo


### PR DESCRIPTION
I'm having an issue with the tmuxinator_completion for version 0.5.0 on OSX. I've used rvm to install the gem, and have the tmuxinator_completion added to my .bashrc

When I use it to tab-complete the commands it works fine for the top-level actions:

```
$ mux 
copy            delete          doctor          help            implode         list            open            update_scripts  version 
```

But it doesn't seem to pickup any of the *.yml files in ~/.tmuxinator because the find command uses a trailing "/" which on OSX get's echoed:

```
$ find ~/.tmuxinator/ -name *.yml
/Users/ddaniels/.tmuxinator//project-dev-ops.yml
/Users/ddaniels/.tmuxinator//project.yml
```

Then it fails to cut properly because it's looking for the 5th field and it is actually the 6th. 

I think the proper solution should avoid making assumptions on the exact path length (e.g. if some setup isn't under a "/home/user/.tmuxinator" but instead "/home/org/users/").

I suggest that piping the find results to basename would work (and I believe should be cross platform compatible)

```
find -L ~/.tmuxinator -name *.yml | xargs -I {} basename {} | sed s:.yml::g
```
