### PR TITLE
Improving tmuxinator_completion to search in sub directories of ~/.tmuxinator

### DIFF
--- a/bin/tmuxinator_completion
+++ b/bin/tmuxinator_completion
@@ -18,7 +18,7 @@ _tmuxinator_commands_complete()
   	case "${prev}" in
   		# complete any action [project_config]
   		start|open|copy|delete)
-			local configs=`find -L ~/.tmuxinator -name *.yml | cut -d/ -f5 | sed s:.yml::g`
+			local configs=`find -L ~/.tmuxinator -name *.yml | cut -d/ -f5- | sed s:.yml::g`
 			COMPREPLY=(`compgen -W "$configs" -- $2`)
 			;;
 		list)


### PR DESCRIPTION
Just a little added char '-' to extend the search of the completion to sub directories in .tmuxinator

This allows me to have nested directories to arrange my ~20 config files a big better
