### PR TITLE
fix error when project yaml file has no deprecation

### DIFF
--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -144,6 +144,7 @@ module Tmuxinator
       deprecations << "DEPRECATION: rbenv/rvm specific options have been replaced by the pre_tab option and will not be supported in 0.8.0." if yaml["rbenv"] || yaml["rvm"]
       deprecations << "DEPRECATION: The tabs option has been replaced by the window option and will not be supported in 0.8.0." if yaml["tabs"].present?
       deprecations << "DEPRECATION: The cli_args option has been replaced by the tmux_options option and will not be supported in 0.8.0." if yaml["cli_args"].present?
+      deprecations
     end
   end
 end


### PR DESCRIPTION
When project yaml file has no deprecations, upon starting it with tmuxinator, an error is thrown.
![by default 2013-07-25 at 8 56 17 am](https://f.cloud.github.com/assets/43447/853165/a65c5c30-f4ce-11e2-9ee0-0f781d96c6f4.png)
