### PR TITLE
Set tmux layout after each pane creation

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -15,30 +15,29 @@ if [ "$?" -eq 1 ]; then
 
   # Create other windows.
   <%- windows.drop(1).each do |window| -%>
-    <%= window.tmux_new_window_command %>
+  <%= window.tmux_new_window_command %>
   <%- end -%>
 
   <%- windows.each do |window| -%>
 
   # Window "<%= window.name %>"
     <%- unless window.panes? -%>
-      <%= window.tmux_pre_window_command %>
-      <%= window.tmux_main_command %>
+  <%= window.tmux_pre_window_command %>
+  <%= window.tmux_main_command %>
     <%- else -%>
       <%- window.panes.each do |pane| -%>
-        <%= pane.tmux_pre_window_command %>
-        <%= pane.tmux_pre_command %>
-        <%= pane.tmux_main_command %>
-  
+  <%= pane.tmux_pre_window_command %>
+  <%= pane.tmux_pre_command %>
+  <%= pane.tmux_main_command %>
+
       <%- unless pane.last? -%>
-        <%= pane.tmux_split_command %>
+  <%= pane.tmux_split_command %>
       <%- end -%>
-      
-      <%= window.tmux_layout_command %>
+  <%= window.tmux_layout_command %>
     <%- end -%>
 
 
-      <%= window.tmux_select_first_pane %>
+  <%= window.tmux_select_first_pane %>
     <%- end -%>
   <%- end -%>
 


### PR DESCRIPTION
The tmux layout needs to be set after each pane creation in order to prevent the lack of space and a "create pane failed: pane too small" error

See #48 

P.S : I updated the file indentation.
