### PR TITLE
Specify directory explicitly when creating new window.

### DIFF
--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -62,7 +62,7 @@ module Tmuxinator
     end
 
     def tmux_new_window_command
-      "#{project.tmux} new-window -t #{tmux_window_target} -n #{name}"
+      "#{project.tmux} new-window -c #{project.root.shellescape} -t #{tmux_window_target} -n #{name}"
     end
 
     def tmux_layout_command

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -59,4 +59,24 @@ describe Tmuxinator::Window do
       end
     end
   end
+
+  describe '#tmux_new_window_command' do
+    let(:project) { double(:project) }
+    let(:window) { Tmuxinator::Window.new(yaml, 0, project) }
+
+    before {
+      project.stub(
+        :name => '',
+        :tmux => 'tmux',
+        :root => '/project/tmuxinator',
+        :base_index => 1
+      )
+    }
+
+    subject(:command) { window.tmux_new_window_command }
+
+    it 'specify default directory using -c directory' do
+      command.should include('-c /project/tmuxinator')
+    end
+  end
 end


### PR DESCRIPTION
When run tmuxinator in tmux session, the default directory of new window
is overrided by the current tmux session default directory.
