### PR TITLE
Require at least version 0.18.0 of thor

### DIFF
--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.required_rubygems_version = ">= 1.8.23"
 
-  spec.add_dependency "thor"
+  spec.add_dependency "thor", ">= 0.18.0"
   spec.add_dependency "activesupport"
   spec.add_dependency "erubis"
 


### PR DESCRIPTION
simply gem installing tmuxinator, it will fail to run due to the `package_name` method being undefined:

```
/Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tmuxinator-0.6.3/lib/tmuxinator/cli.rb:12:in `<class:Cli>': undefined method `package_name' for Tmuxinator::Cli:Class (NoMethodError)
    from /Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tmuxinator-0.6.3/lib/tmuxinator/cli.rb:2:in `<module:Tmuxinator>'
    from /Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tmuxinator-0.6.3/lib/tmuxinator/cli.rb:1:in `<top (required)>'
    from /Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tmuxinator-0.6.3/lib/tmuxinator.rb:9:in `<top (required)>'
    from /Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/wil/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tmuxinator-0.6.3/bin/mux:5:in `<top (required)>'
    from /Users/wil/.rbenv/versions/1.9.3-p194/bin/mux:23:in `load'
    from /Users/wil/.rbenv/versions/1.9.3-p194/bin/mux:23:in `<main>'
```
