### PR TITLE
Fix bash completion with single arg.

### DIFF
--- a/completion/tmuxinator.bash
+++ b/completion/tmuxinator.bash
@@ -5,7 +5,10 @@ _tmuxinator() {
     local word="${COMP_WORDS[COMP_CWORD]}"
 
     if [ "$COMP_CWORD" -eq 1 ]; then
-        COMPREPLY=( $(compgen -W "$(tmuxinator commands)" -- "$word") )
+        local commands="$(compgen -W "$(tmuxinator commands)" -- "$word")"
+        local projects="$(compgen -W "$(tmuxinator completions start)" -- "$word")"
+
+        COMPREPLY=( $commands $projects )
     else
         local words=("${COMP_WORDS[@]}")
         unset words[0]


### PR DESCRIPTION
Previously the script was assuming that a single arg meant that a mux
command must be next.  However, mux now supports calling just
`mux projet-name`, meaning the bash completion script should do the
same.
