### PR TITLE
Allow specifying an array of commands in the yaml

### DIFF
--- a/lib/tmuxinator/util.rb
+++ b/lib/tmuxinator/util.rb
@@ -10,5 +10,9 @@ module Tmuxinator
     def yes_no(condition)
       condition ? say("Yes", :green) : say("No", :red)
     end
+
+    def flatten_command(command)
+      [command].flatten.compact.reject { |c| c.strip.empty? }.join(" && ")
+    end
   end
 end

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -1,5 +1,7 @@
 module Tmuxinator
   class Window
+    include Tmuxinator::Util
+
     attr_reader :name, :panes, :layout, :command, :index, :project
 
     def initialize(window_yaml, index, project)
@@ -19,7 +21,7 @@ module Tmuxinator
 
         @panes = build_panes(value["panes"])
       else
-        @command = value
+        @command = flatten_command(value)
       end
     end
 

--- a/spec/fixtures/sample.yml
+++ b/spec/fixtures/sample.yml
@@ -17,7 +17,9 @@ windows:
         - vim
         - #empty, will just run plain bash
         - top
-  - shell: git pull
+  - shell:
+    - git pull
+    - git merge
   - guard:
       layout: tiled
       pre:

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -231,6 +231,13 @@ describe Tmuxinator::Project do
     end
   end
 
+  describe "#command" do
+    it "flattens the command" do
+      window = project.windows.keep_if{ |w| w.name == "shell" }.first
+      expect(window.command).to eq("git pull && git merge")
+    end
+  end
+
   describe "#pre" do
     subject(:pre) { project.pre }
 

--- a/spec/lib/tmuxinator/util_spec.rb
+++ b/spec/lib/tmuxinator/util_spec.rb
@@ -1,4 +1,21 @@
 require "spec_helper"
 
 describe Tmuxinator::Util do
+  let(:util) { Object.new.extend(Tmuxinator::Util) }
+
+  describe "#flatten_command" do
+    it "flattens and joins an array" do
+      command = [
+        "command 1",
+        "",
+        "command 2",
+      ]
+      expect(util.flatten_command(command)).to eq("command 1 && command 2")
+    end
+
+    it "passes through a string" do
+      command = "command 1"
+      expect(util.flatten_command(command)).to eq("command 1")
+    end
+  end
 end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -48,6 +48,28 @@ describe Tmuxinator::Window do
     end
   end
 
+  describe "#command" do
+    context "command is an array" do
+      before do
+        yaml["editor"] = ["git fetch", "git status"]
+      end
+
+      it "returns the flattened command" do
+        expect(window.command).to eq "git fetch && git status"
+      end
+    end
+
+    context "command is a string" do
+      before do
+        yaml["editor"] = "vim"
+      end
+
+      it "returns the command" do
+        expect(window.command).to eq "vim"
+      end
+    end
+  end
+
   describe "#build_panes" do
     context "no panes" do
       before do


### PR DESCRIPTION
Hi. I tried upgrading from tmuxinator 0.5.0 to 0.6.5 today. Things were fine except one feature I was using. Version 0.5.0 allowed you to specify a list of commands for a pane. e.g.:

``` yaml
windows:
  - shell:
    - git fetch
    - ls
```

These would then be flattened into the command `git fetch && ls`. This patch adds this functionality back in. It includes test coverage.

I placed the flatten_command method into Tmuxinator::Util. My reasoning was that it might make sense to allow passing an array of commands to `panes:` also, but I didn't add that in here. Let me know if anything needs to be moved around.
