### PR TITLE
add option to call other programs than tmux, for e.g byobu-tmux

### DIFF
--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -15,6 +15,9 @@ root: ~/
 # Pass command line options to tmux. Useful for specifying a different tmux.conf.
 # tmux_options: -f ~/.tmux.mac.conf
 
+# Change the command to call tmux, it is by default "tmux". This can be used by derivatives/wrappers like byobu (byobu-tmux)
+# tmux_cmd: tmux
+
 windows:
   - editor:
       layout: main-vertical

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -65,7 +65,16 @@ module Tmuxinator
     end
 
     def tmux
-      "tmux#{tmux_options}#{socket}"
+      "#{tmux_cmd}#{tmux_options}#{socket}"
+    end
+
+    # used by tmux derivates/wrappers, e.g byobu - use byobu-tmux
+    def tmux_cmd
+      if yaml["tmux_cmd"].present?
+        yaml["tmux_cmd"]
+      else
+        "tmux"
+      end
     end
 
     def socket


### PR DESCRIPTION
A small change to let me call byobu from it. 

If it makes sense, perhaps the tmux function can just use 1 variable, i.e "#{tmux_cmd}#{tmux_options}#{socket}"  can be combined into 1 variable, that might make my change seem less hacky :P
