### PR TITLE
Fix running commands in the panes

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -28,13 +28,13 @@ if [ "$?" -eq 1 ]; then
       <%- window.panes.each do |pane| -%>
   <%= pane.tmux_pre_window_command %>
   <%= pane.tmux_pre_command %>
-  <%= pane.tmux_main_command %>
-
       <%- unless pane.last? -%>
   <%= pane.tmux_split_command %>
       <%- end -%>
-  <%= window.tmux_layout_command %>
+  <%= pane.tmux_main_command %>
+
     <%- end -%>
+  <%= window.tmux_layout_command %>
 
 
   <%= window.tmux_select_first_pane %>


### PR DESCRIPTION
Hello,

after upgrading to 0.6.5  I encounter error, when I tried to run command in multi pane windows, they didn't get ran at all with tmux warning: `can't find pane: n` where `n` was the number of the pane.

After some debugging I found that command is called before pane was created. My env:

```
tmuxinator 0.6.5
tmux 1.8.0 HEAD
zsh 5.0.2
```

My testing configuration:
    # ~/.tmuxinator/sct.yml

```
project_name: Client
project_root: ~/Projects/fun/client.com
pre_windows: 1.9.3@client.com
windows:
  - git:
  - editor: vim
  - shell:
      layout: main-vertical
      panes:
        - bundle exec padrino start -p 3001
        - bundle exec padrino console
        -
  - test: rspec && cucumber
```

This patch fixes the problem for me, but I have not been able to solve how I should add regression test for it. Any directions would be appreciated.

Hope it all makes sense and thank you for this timesaver.
