### PR TITLE
Refactor Window#build_panes to always return an Array

### DIFF
--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -25,12 +25,8 @@ module Tmuxinator
     end
 
     def build_panes(pane_yml)
-      if pane_yml.is_a?(Array)
-        pane_yml.map.with_index do |pane_cmd, index|
-          Tmuxinator::Pane.new(pane_cmd, index, project, self)
-        end
-      else
-        Tmuxinator::Pane.new(pane_yml, index, project, self)
+      Array(pane_yml).map.with_index do |pane_cmd, index|
+        Tmuxinator::Pane.new(pane_cmd, index, project, self)
       end
     end
 

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -53,8 +53,21 @@ describe Tmuxinator::Window do
         window.panes
       end
 
-      it "returns one pane" do
-        expect(window.panes).to eql pane
+      it "returns one pane in an Array" do
+        expect(window.panes).to eql [pane]
+      end
+    end
+
+    context "with nil" do
+      let(:panes) { nil }
+
+      it "doesn't create any panes" do
+        expect(Tmuxinator::Pane).to_not receive(:new)
+        window.panes
+      end
+
+      it "returns an empty Array" do
+        expect(window.panes).to be_empty
       end
     end
   end


### PR DESCRIPTION
This is because it is treated like an Array in `Window#panes?` and in `lib/tmuxinator/assets/template.erb`

Without this, the following YAML would fail:

``` yaml
windows:
  - vim:
      pre: "some_command"
```

and so would this:

``` yaml
windows:
  - vim:
      panes: "vim"
```

I also refactored the specs a little :smile:
