### PR TITLE
travis test matrix against multiple tmux versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,23 @@ language: ruby
 rvm:
   - "1.9.3"
   - "2.0.0"
+env:
+  - TMUX_VERSION=master
+  - TMUX_VERSION=1.8
+  - TMUX_VERSION=1.7
+  - TMUX_VERSION=1.6
+  - TMUX_VERSION=1.5
+matrix:
+  allow_failures:
+    - env: TMUX_VERSION=1.7
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libevent-dev libncurses-dev
+  - git clone git://git.code.sf.net/p/tmux/tmux-code tmux
+  - cd tmux
+  - git checkout $TMUX_VERSION
+  - sh autogen.sh
+  - ./configure && make && sudo make install
+  - cd ..
+  - tmux -V
 script: bundle exec rspec spec


### PR DESCRIPTION
Update `.travis.yml` config allows testing against multiple versions of tmux using [build matrix](http://about.travis-ci.org/docs/user/build-configuration/#The-Build-Matrix).

Preview: https://travis-ci.org/tony/tmuxinator/builds/12659191.

It is currently set to test versions 1.5 - 1.8 and the latest codebase.

Can be configured to allow versions to be tested and fail optionally with:

``` yaml
matrix:
  allow_failures:
    - env: TMUX_VERSION=1.5
```

1.5 could be any `env` variable set.

I made another ticket for this on remiprev/teamocil#51 (a similar project) since both use travis and tmux.
