### PR TITLE
Remove use of grep for base-index

### DIFF
--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -136,15 +136,11 @@ module Tmuxinator
     end
 
     def get_pane_base_index
-      get_value_for_key('pane-base-index')
+      tmux_config["pane-base-index"]
     end
 
     def get_base_index
-      get_value_for_key('base-index')
-    end
-
-    def grep_for_key(key)
-      "grep -A 0 -B 0 #{key}"
+      tmux_config["base-index"]
     end
 
     def show_tmux_options
@@ -153,8 +149,22 @@ module Tmuxinator
 
     private
 
-    def get_value_for_key(key)
-      `#{show_tmux_options} | #{grep_for_key(key)}`.split(/\s/).last
+    def tmux_config
+      @tmux_config ||= extract_tmux_config
+    end
+
+    def extract_tmux_config
+      options_hash = {}
+
+      options_string = `#{show_tmux_options}`
+
+      options_string.split("\n").map do |entry|
+        key, value = entry.split("\s")
+        options_hash[key] = value
+        options_hash
+      end
+
+      options_hash
     end
   end
 end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -153,49 +153,20 @@ describe Tmuxinator::Project do
     end
   end
 
-  describe '#get_pane_base_index' do
-    it 'will extra the pane_base_index from tmux_options' do
-      project.stub(show_tmux_options: tmux_options(pane_base_index: 3))
+  describe "#get_pane_base_index" do
+    it "extracts the pane_base_index from tmux_options" do
+      project.stub(show_tmux_options: tmux_config(pane_base_index: 3))
 
-      expect(project.get_pane_base_index).to eq('3')
+      expect(project.get_pane_base_index).to eq("3")
     end
   end
 
-  describe '#get_base_index' do
-    it 'will extract the base index from options' do
-      project.stub(show_tmux_options: tmux_options(base_index: 1))
+  describe "#get_base_index" do
+    it "extracts the base index from options" do
+      project.stub(show_tmux_options: tmux_config(base_index: 1))
 
-      expect(project.get_base_index).to eq('1')
+      expect(project.get_base_index).to eq("1")
     end
-
-    it 'will extra when extra grep lines are configured' do
-      ENV['GREP_OPTIONS'] = '-A 3 -B 3'
-      project.stub(show_tmux_options: tmux_options(base_index: 1))
-
-      expect(project.get_base_index).to eq('1')
-    end
-  end
-
-  def tmux_options(options={})
-    standard_options = [
-      "assume-paste-time 1",
-      "bell-action any",
-      "bell-on-alert off",
-    ]
-
-    if base_index  = options.fetch(:base_index) {1}
-     standard_options << "base-index #{base_index}"
-    end
-
-    if pane_base_index  = options.fetch(:pane_base_index) {1}
-     standard_options << "pane-base-index #{pane_base_index}"
-    end
-
-    standard_options << "status-fg colour248"
-    standard_options << "status-interval 15"
-    standard_options << "status-justify left"
-
-    "echo '#{standard_options.join("\n")}'"
   end
 
   describe "#base_index" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,3 +34,21 @@ ensure
   $stdout = orig_stdout
   $stderr = orig_stderr
 end
+
+def tmux_config(options = {})
+  standard_options = [
+    "assume-paste-time 1",
+    "bell-action any",
+    "bell-on-alert off",
+  ]
+
+  if base_index  = options.fetch(:base_index) {1}
+    standard_options << "base-index #{base_index}"
+  end
+
+  if pane_base_index  = options.fetch(:pane_base_index) {1}
+    standard_options << "pane-base-index #{pane_base_index}"
+  end
+
+  "echo '#{standard_options.join("\n")}'"
+end


### PR DESCRIPTION
I noticed that I had problems with tmuxinator due to the fact that I configure my GREP_OPTIONS to show me 3 lines above and below by default. After looking into the issue I realized that we could eliminate this problem by specifying the `-A 0 -B 0` flags so I wrote a few specs and done this.

After cleaning it up, I thought it may be a better idea to remove all reliance on the system grep and do all the work in ruby so I done this. This also prevents a second call out to `tmux show-options`.

Let me know what you think. I'm happy to make adjustments! Thanks for this project, I've really enjoyed it!
