### PR TITLE
Fix path for Rails log directory in sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ windows:
         - vim
         - guard
   - server: bundle exec rails s
-  - logs: tail -f logs/development.log
+  - logs: tail -f log/development.log
 ```
 
 ## Windows

--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -25,4 +25,4 @@ windows:
         - vim
         - guard
   - server: bundle exec rails s
-  - logs: tail -f logs/development.log
+  - logs: tail -f log/development.log


### PR DESCRIPTION
This was previously fixed in 01446a1 but then lost in 3614b80

I've updated the README for consistency
