### PR TITLE
Optional project_root. Exit when project_name not specified

### DIFF
--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -74,6 +74,7 @@ module Tmuxinator
 
         unless project.name?
           puts "Your project file didn't specify a 'project_name'"
+          exit!
         end
 
         project

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -27,7 +27,7 @@ module Tmuxinator
     end
 
     def name
-      yaml["project_name"].presence.try(:shellescape) || yaml["name"].shellescape
+      (yaml["project_name"].presence || yaml["name"].presence).try(:shellescape)
     end
 
     def pre


### PR DESCRIPTION
Fixes #144
@jcristovao please elaborate how this would look like:

> 1) Use the current directory as a base point for launching
