### PR TITLE
Support config file inside a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ Add `export DISABLE_AUTO_TITLE=true` to your `.zshrc` or `.bashrc`
 ### How can I ship a tmuxinator config with my project?
 
 1. Include the config file in your project, e.g. for Rails, you could put it in <rails-project-root>/config/tmuxinator.yml
-2. You'll probably want to set the `root` property to be relative to the config file, so members of your project can keep it any folder location on their respective machines. To do so, use `#{config_dir}` in the YML file's `root` value, e.g. if you put the config at <rails-project-root>/config/tmuxinator.yml, you want this line: `root: "#{config_dir}/.."`.
-3. To run it, simply point to the direct file path, e.g. `tmuxinator config/tmuxinator.yml`
+2. To run it, simply point to the direct file path, e.g. `tmuxinator config/tmuxinator.yml`
+3. On a typical project, you'll want to set the `root` property to your project's home, so a special variable `config_dir` is provided to support root paths relative to the folder housing the tmuxinator config file. In our Rails example with the YML in <project-home>/config, you'll want this line: `root: "#{config_dir}/.."`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Add `export DISABLE_AUTO_TITLE=true` to your `.zshrc` or `.bashrc`
 
 1. Include the config file in your project, e.g. for Rails, you could put it in config/tmuxinator.yml
 2. Set your root relative to the config dir like: `root: "#{config_dir}/.."`
-3. Specify the direct file path, e.g. `tmuxinator config/tmuxinator.yml"
+3. Specify the direct file path, e.g. `tmuxinator config/tmuxinator.yml`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ Add `export DISABLE_AUTO_TITLE=true` to your `.zshrc` or `.bashrc`
 
 ### How can I ship a tmuxinator config with my project?
 
-1. Include the config file in your project, e.g. for Rails, you could put it in config/tmuxinator.yml
-2. Set your root relative to the config dir like: `root: "#{config_dir}/.."`
-3. Specify the direct file path, e.g. `tmuxinator config/tmuxinator.yml`
+1. Include the config file in your project, e.g. for Rails, you could put it in <rails-project-root>/config/tmuxinator.yml
+2. You'll probably want to set the `root` property to be relative to the config file, so members of your project can keep it any folder location on their respective machines. To do so, use `#{config_dir}` in the YML file's `root` value, e.g. if you put the config at <rails-project-root>/config/tmuxinator.yml, you want this line: `root: "#{config_dir}/.."`.
+3. To run it, simply point to the direct file path, e.g. `tmuxinator config/tmuxinator.yml`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ tmuxinator version
 
 Add `export DISABLE_AUTO_TITLE=true` to your `.zshrc` or `.bashrc`
 
+### How can I ship a tmuxinator config with my project?
+
+1. Include the config file in your project, e.g. for Rails, you could put it in config/tmuxinator.yml
+2. Set your root relative to the config dir like: `root: "#{config_dir}/.."`
+3. Specify the direct file path, e.g. `tmuxinator config/tmuxinator.yml"
+
 ## Contributing
 
 To contribute, please read the [contributing guide](https://github.com/aziz/tmuxinator/blob/master/CONTRIBUTING.md).

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -58,15 +58,7 @@ module Tmuxinator
         end
 
         config_path = Tmuxinator::Config.project(name)
-
-        yaml = begin
-          YAML.load(File.read(config_path))
-        rescue SyntaxError, StandardError
-          puts "Failed to parse config file. Please check your formatting."
-          exit!
-        end
-
-        project = Tmuxinator::Project.new(yaml)
+        project = Tmuxinator::Project.new(config_path)
 
         unless project.windows?
           puts "Your project file should include some windows."

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -57,8 +57,13 @@ module Tmuxinator
           exit!
         end
 
-        config_path = Tmuxinator::Config.project(name)
-        project = Tmuxinator::Project.new(config_path)
+        begin
+          config_path = Tmuxinator::Config.project(name)
+          yaml = YAML.load(File.read(config_path))
+          project = Tmuxinator::Project.new(yaml, { config_path: config_path })
+        rescue SyntaxError, StandardError
+          exit! "Failed to parse config file. Please check your formatting."
+        end
 
         unless project.windows?
           puts "Your project file should include some windows."

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -35,6 +35,7 @@ module Tmuxinator
       end
 
       def project(name)
+        return name if name =~ /\.yml$/ and File.file?(name)
         projects = Dir.glob("#{root}/**/*.yml")
         project_file = projects.detect { |project| project =~ /^#{name}.yml$/ }
         project_file || "#{root}/#{name}.yml"

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -5,14 +5,9 @@ module Tmuxinator
 
     attr_reader :yaml
 
-    def initialize(config_path)
-      @config_path = config_path
-      begin
-        @yaml = YAML.load(File.read(config_path))
-      rescue SyntaxError, StandardError
-        puts "Failed to parse config file. Please check your formatting."
-        exit!
-      end
+    def initialize(yaml, context={})
+      @yaml = yaml
+      @config_path = context[:config_path]
     end
 
     def render
@@ -30,7 +25,7 @@ module Tmuxinator
 
     def root
       root_path = yaml["project_root"].presence || yaml["root"]
-      root_path.gsub /\#\{config_dir\}/, File.expand_path(File.dirname(@config_path))
+      root_path.gsub(/\#\{config_dir\}/) { File.expand_path(File.dirname(@config_path)) }
     end
 
     def name

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -3,11 +3,11 @@ module Tmuxinator
     include Tmuxinator::Util
     include Tmuxinator::Deprecations
 
-    attr_reader :yaml
+    attr_reader :yaml, :context
 
     def initialize(yaml, context={})
       @yaml = yaml
-      @config_path = context[:config_path]
+      @context = context
     end
 
     def render
@@ -25,7 +25,10 @@ module Tmuxinator
 
     def root
       root_path = yaml["project_root"].presence || yaml["root"]
-      root_path.gsub(/\#\{config_dir\}/) { File.expand_path(File.dirname(@config_path)) }
+      File.expand_path root_path.gsub(/\#\{config_dir\}/) { 
+        config_path = @context[:config_path]
+        File.dirname(config_path)
+      }
     end
 
     def name

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -5,8 +5,14 @@ module Tmuxinator
 
     attr_reader :yaml
 
-    def initialize(yaml)
-      @yaml = yaml
+    def initialize(config_path)
+      @config_path = config_path
+      begin
+        @yaml = YAML.load(File.read(config_path))
+      rescue SyntaxError, StandardError
+        puts "Failed to parse config file. Please check your formatting."
+        exit!
+      end
     end
 
     def render
@@ -23,7 +29,8 @@ module Tmuxinator
     end
 
     def root
-      yaml["project_root"].presence || yaml["root"]
+      root_path = yaml["project_root"].presence || yaml["root"]
+      root_path.gsub /\#\{config_dir\}/, File.expand_path(File.dirname(@config_path))
     end
 
     def name

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,10 +1,12 @@
 FactoryGirl.define do
   factory :project, :class => Tmuxinator::Project do
+
+    config_path = File.expand_path("spec/fixtures/sample.yml")
     ignore do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/sample.yml")}")) }
+      file { YAML.load(File.read(config_path)) }
     end
 
-    initialize_with { Tmuxinator::Project.new(file) }
+    initialize_with { Tmuxinator::Project.new(file, config_path: config_path) }
   end
 
   factory :project_with_deprecations, :class => Tmuxinator::Project do
@@ -14,4 +16,15 @@ FactoryGirl.define do
 
     initialize_with { Tmuxinator::Project.new(file) }
   end
+
+  factory :project_with_context, :class => Tmuxinator::Project do
+
+    config_path = File.expand_path("spec/fixtures/sample.context.yml")
+    ignore do
+      file { YAML.load(File.read(config_path)) }
+    end
+
+    initialize_with { Tmuxinator::Project.new(file, config_path: config_path) }
+  end
+
 end

--- a/spec/fixtures/sample.context.yml
+++ b/spec/fixtures/sample.context.yml
@@ -1,0 +1,40 @@
+# ~/.tmuxinator/sample.context.yml
+# sample using config file context
+
+name: sample
+root: "#{config_dir}/../.." # point to tmuxinator project root
+socket_name: foo # Remove to use default socket
+pre: sudo /etc/rc.d/mysqld start # Runs before everything
+pre_window: rbenv shell 2.0.0-p247 # Runs in each tab and pane
+tmux_options: -f ~/.tmux.mac.conf # Pass arguments to tmux
+windows:
+  - editor:
+      pre:
+        - echo "I get run in each pane, before each pane command!"
+        -
+      layout: main-vertical
+      panes:
+        - vim
+        - #empty, will just run plain bash
+        - top
+        - pane_with_multiple_commands:
+            - ssh server
+            - echo "Hello"
+  - shell:
+    - git pull
+    - git merge
+  - guard:
+      layout: tiled
+      pre:
+        - echo "I get run in each pane."
+        - echo "Before each pane command!"
+      panes:
+        -
+        - #empty, will just run plain bash
+        -
+  - database: bundle exec rails db
+  - server: bundle exec rails s
+  - logs: tail -f log/development.log
+  - console: bundle exec rails c
+  - capistrano:
+  - server: ssh user@example.com

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -3,11 +3,16 @@ require "spec_helper"
 describe Tmuxinator::Project do
   let(:project) { FactoryGirl.build(:project) }
   let(:project_with_deprecations) { FactoryGirl.build(:project_with_deprecations) }
+  let(:project_with_context) { FactoryGirl.build(:project_with_context) }
 
   describe "#initialize" do
     context "valid yaml" do
       it "creates an instance" do
         expect(project).to be_a(Tmuxinator::Project)
+      end
+      it "includes calling context" do
+        expect(project.context).to_not be_empty
+        expect(project.context[:config_path]).to_not be_empty
       end
     end
   end
@@ -35,13 +40,19 @@ describe Tmuxinator::Project do
   describe "#root" do
     context "without deprecations" do
       it "gets the root" do
-        expect(project.root).to eq "~/test"
+        expect(project.root).to eq File.expand_path("~/test")
       end
     end
 
     context "with deprecations" do
       it "still gets the root" do
-        expect(project_with_deprecations.root).to eq "~/test"
+        expect(project_with_deprecations.root).to eq File.expand_path("~/test")
+      end
+    end
+
+    context "with context" do
+      it "uses relative path for root" do
+        expect(project_with_context.root).to eq File.expand_path("#{File.dirname(__FILE__)}/../../..")
       end
     end
   end


### PR DESCRIPTION
Wanting to ship a project's tmuxinator config with the project, so would like a way people can directly open the file as well as specify a project root relative to the config file. The new FAQ entry in the README explains how someone could use it.