### PR TITLE
Clear rbenv variables before starting tmux

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -1,4 +1,9 @@
 #!<%= ENV["SHELL"] || "/bin/bash" %>
+
+# Clear rbenv variables before starting tmux
+unset RBENV_VERSION
+unset RBENV_DIR
+
 <%= tmux %> start-server\; has-session -t <%= name %> 2>/dev/null
 
 if [ "$?" -eq 1 ]; then


### PR DESCRIPTION
Relates to #99

This one is still an issue for me and I don't want to have this:

``` yaml
pre:
  - unset RBENV_VERSION
  - unset RBENV_DIR
```

in every project setup I have.

What do you think?
