### PR TITLE
Changed which... > /dev/null to which -s ...

### DIFF
--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -19,7 +19,7 @@ module Tmuxinator
       end
 
       def installed?
-        Kernel.system("which -s tmux")
+        Kernel.system("type tmux > /dev/null")
       end
 
       def version


### PR DESCRIPTION
OS X 10.10 seems to have done something causing which tmux > /dev/null to return false

Which does however have an option for not outputting what it found but return 0 or 1 depending on if it was found, achieving the same goal as the previous version.

Tmuxinator still fails since it can't find tmux when using it via homebrew, this seems to be an issue with $PATH not being set so technically not a tmuxinator issue.
