### PR TITLE
Escape path string in order to handle paths with spaces, parentheses etc...

### DIFF
--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -26,7 +26,7 @@ module Tmuxinator
 
     def root
       root = yaml["project_root"] || yaml["root"]
-      root.blank? ? nil : File.expand_path(root)
+      root.blank? ? nil : File.expand_path(root).shellescape
     end
 
     def name


### PR DESCRIPTION
Will work with for example ~/Dropbox (My Company Dropbox)/ and tmuxinator root to set to current directory (.)
