### PR TITLE
Add "open" to command list

### DIFF
--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -6,7 +6,7 @@ module Tmuxinator
 
     def initialize(*args)
       super
-      @command_list = %w(commands copy debug delete doctor help implode list start version)
+      @command_list = %w(commands copy debug delete doctor help implode list open start version)
     end
 
     package_name "tmuxinator" unless Gem::Version.create(Thor::VERSION) < Gem::Version.create("0.18")


### PR DESCRIPTION
I noticed that there is a mapping for `open` to the `new` command. I was looking for an `open` command, but it was not listed. This change will make the option more apparent.
