### PR TITLE
Escape project root path once and only once

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -18,7 +18,7 @@ if [ "$?" -eq 1 ]; then
   <%- if Tmuxinator::Config.version < 1.7 -%>
   # Set the default path for versions prior to 1.7
   <%- if root? -%>
-  <%= tmux %> set-option -t <%= name %> <%= Tmuxinator::Config.default_path_option %> <%= root.shellescape -%> 1>/dev/null
+  <%= tmux %> set-option -t <%= name %> <%= Tmuxinator::Config.default_path_option %> <%= root -%> 1>/dev/null
   <%- end -%>
   <%- end -%>
 

--- a/lib/tmuxinator/assets/wemux_template.erb
+++ b/lib/tmuxinator/assets/wemux_template.erb
@@ -12,7 +12,7 @@ if [ "$?" -eq 127 ]; then
 
   # Set the default path.
   <%- if root? -%>
-  <%= tmux %> set-option -t <%= name %> <%= Tmuxinator::Config.default_path_option %> <%= root.shellescape -%> 1>/dev/null
+  <%= tmux %> set-option -t <%= name %> <%= Tmuxinator::Config.default_path_option %> <%= root -%> 1>/dev/null
   <%- end -%>
 
   # Create other windows.

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -75,7 +75,7 @@ module Tmuxinator
     end
 
     def tmux_new_window_command
-      path = project.root? ? "#{Tmuxinator::Config.default_path_option} #{File.expand_path(project.root).shellescape}" : nil
+      path = project.root? ? "#{Tmuxinator::Config.default_path_option} #{File.expand_path(project.root)}" : nil
       "#{project.tmux} new-window #{path} -t #{tmux_window_target} -n #{name}"
     end
 


### PR DESCRIPTION
Hi,
#251 fixed one bug, but created another. It made sure that the path was escaped when `cd`ing to the directory, but it meant that the path was double-escaped elsewhere. This PR makes sure that the project root path is escaped once and only once every time it is used.

Fixes #256
