### PR TITLE
Ensure `mux copy` copies existing file over

### DIFF
--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -76,11 +76,9 @@ module Tmuxinator
 
       exit!("Project #{existing} doesn't exist!") unless Tmuxinator::Config.exists?(existing)
 
-      if Tmuxinator::Config.exists?(new)
-        if yes?("#{new} already exists, would you like to overwrite it?", :red)
-          say "Overwriting #{new}"
-          FileUtils.copy_file(existing_config_path, new_config_path)
-        end
+      if !Tmuxinator::Config.exists?(new) or yes?("#{new} already exists, would you like to overwrite it?", :red)
+        say "Overwriting #{new}" if Tmuxinator::Config.exists?(new)
+        FileUtils.copy_file(existing_config_path, new_config_path)
       end
 
       Kernel.system("$EDITOR #{new_config_path}")


### PR DESCRIPTION
#254 introduced a bug whereby `mux copy existing new` wasn't copying `existing.yml` to `new.yml` unless `new.yml` already existed.
