### PR TITLE
Interpret configuration file as a template

### DIFF
--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -71,7 +71,7 @@ module Tmuxinator
         config_path = Tmuxinator::Config.project(name)
 
         yaml = begin
-          YAML.load(File.read(config_path))
+          YAML.load(Erubis::Eruby.new(File.read(config_path)).result(binding))
         rescue SyntaxError, StandardError
           puts "Failed to parse config file. Please check your formatting."
           exit!


### PR DESCRIPTION
Hi!

In order to share a configuration file on different environments, some parts should be customizable. With this patch, this configuration works:

``` YAML
name: my_project
root: <%= ENV["MY_CUSTOM_DIR"] %>

windows:
  - bash:
    - #empty
```
