### PR TITLE
Add fish autocompletion for mux

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add the following to your `~/.zshrc`:
 
 Move `tmuxinator.fish` to your `completions` folder:
 
-    cp ~/.bin/tmuxinator.fish ~/.config/fish/completions/
+    cp ~/.bin/{mux,tmuxinator}.fish ~/.config/fish/completions/
 
 ## Usage
 

--- a/completion/mux.fish
+++ b/completion/mux.fish
@@ -1,0 +1,16 @@
+function __fish_mux_using_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -gt 1 ]
+    if [ $argv[1] = $cmd[2] ]
+      return 0
+    end
+  end
+  return 1
+end
+
+complete -f -c mux -a '(mux completions start)'
+complete -f -c mux -a '(mux commands)'
+complete -f -c mux -n '__fish_mux_using_command start' -a '(mux completions start)'
+complete -f -c mux -n '__fish_mux_using_command open' -a '(mux completions open)'
+complete -f -c mux -n '__fish_mux_using_command copy' -a '(mux completions copy)'
+complete -f -c mux -n '__fish_mux_using_command delete' -a '(mux completions delete)'


### PR DESCRIPTION
Fish only autocompletes if script has the same name as binary, we can't place autocompletion for both `mux` and `tmuxinator` in one file =(