### PR TITLE
Add window/root override

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -13,7 +13,11 @@ if [ "$?" -eq 1 ]; then
   <%= pre %>
 
   # Create the session and the first window.
+  <%- if windows.first.root? -%>
+  TMUX= <%= tmux %> new-session -d -s <%= name %> -n <%= windows.first.name %> <%= Tmuxinator::Config.default_path_option %> <%= windows.first.root %>
+  <%- else -%>
   TMUX= <%= tmux %> new-session -d -s <%= name %> -n <%= windows.first.name %>
+  <%- end -%>
 
   <%- if Tmuxinator::Config.version < 1.7 -%>
   # Set the default path for versions prior to 1.7

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -26,7 +26,8 @@ module Tmuxinator
     end
 
     def tmux_split_command
-      "#{project.tmux} splitw -t #{tab.tmux_window_target}"
+      path = tab.root? ? "#{Tmuxinator::Config.default_path_option} #{tab.root}" : nil
+      "#{project.tmux} splitw #{path} -t #{tab.tmux_window_target}"
     end
 
     def last?

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -12,16 +12,48 @@ describe Tmuxinator::Window do
       }
     }
   end
+  let(:yaml_root) do
+    {
+      "editor" => {
+        "root" => "/project/override",
+        "root?" => true,
+        "pre" => ["echo 'I get run in each pane.  Before each pane command!'", nil],
+        "layout" => "main-vertical",
+        "panes" => panes
+      }
+    }
+  end
 
   let(:window) { Tmuxinator::Window.new(yaml, 0, project) }
+  let(:window_root) { Tmuxinator::Window.new(yaml_root, 0, project) }
 
   before do
-    allow(project).to receive_messages(:tmux => "tmux", :name => "test", :base_index => 1)
+    allow(project).to receive_messages(
+       :tmux => "tmux",
+       :name => "test",
+       :base_index => 1,
+       :root => "/project/tmuxinator",
+       :root? => true
+     )
   end
 
   describe "#initialize" do
     it "creates an instance" do
       expect(window).to be_a(Tmuxinator::Window)
+    end
+  end
+
+  describe "#root" do
+    context "without window root" do
+      it "gets the project root" do
+        expect(window.root).to include("/project/tmuxinator")
+      end
+    end
+
+    context "with window root" do
+      it "gets the window root" do
+        expect(window_root.root).to include("/project/override")
+      end
     end
   end
 


### PR DESCRIPTION
Add support for window/root override #175 and propagate path through initialization of panes.

```yaml
name: test
root: ~/projects/company

windows:
  - small_project:
      root: ~/projects/company/small_project
      panes:
        - start this
        - start that
        - 
  - big_project:
      root: ~/projects/company/big_project
      panes:
        - 
        - 
  - project_root:
      panes:
        - 
        - 
```