### PR TITLE
Add option "tmux_detached" for detach client

### DIFF
--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -21,6 +21,9 @@ root: ~/
 # Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
 # startup_window: logs
 
+# for option to start detached
+# tmux_detached: true
+
 windows:
   - editor:
       layout: main-vertical

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -60,8 +60,10 @@ if [ "$?" -eq 1 ]; then
   <%= tmux %> select-window -t <%= startup_window %>
 fi
 
+<% unless detached? %>
 if [ -z "$TMUX" ]; then
   <%= tmux %> -u attach-session -t <%= name %>
 else
   <%= tmux %> -u switch-client -t <%= name %>
 fi
+<%- end -%>

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -43,6 +43,10 @@ module Tmuxinator
       end
     end
 
+    def detached?
+      yaml["tmux_detached"]
+    end
+
     def pre_window
       if rbenv?
         "rbenv shell #{yaml["rbenv"]}"

--- a/spec/fixtures/sample.yml
+++ b/spec/fixtures/sample.yml
@@ -7,6 +7,7 @@ socket_name: foo # Remove to use default socket
 pre: sudo /etc/rc.d/mysqld start # Runs before everything
 pre_window: rbenv shell 2.0.0-p247 # Runs in each tab and pane
 tmux_options: -f ~/.tmux.mac.conf # Pass arguments to tmux
+tmux_detached: false
 windows:
   - editor:
       pre:

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -328,4 +328,29 @@ describe Tmuxinator::Project do
       end
     end
   end
+
+  describe "#detached?" do
+    subject(:detached) { project.detached? }
+
+    context "tmux_detached is true in yaml" do
+      before { project.yaml["tmux_detached"] = true }
+
+      it "returns true" do
+        expect(detached).to be_truthy
+      end
+    end
+
+    context "tmux_detached is not defined in yaml" do
+      it "returns false" do
+        expect(detached).to be_falsey
+      end
+    end
+
+    context "tmux_detached is false in yaml" do
+      it "returns false" do
+        expect(detached).to be_falsey
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
This option specifies if tmux start with attached or detached state.
Start attached when "false" or option not defined, otherwise detached.
As requested in #191 #224 