### PR TITLE
Removes command that causes errors

### DIFF
--- a/completion/tmuxinator.zsh
+++ b/completion/tmuxinator.zsh
@@ -2,7 +2,7 @@
 
 _tmuxinator() {
   local commands projects
-  commands=(${(f)"$(tmuxinator commands zsh)"})
+  commands=(${(f)"$(tmuxinator commands)"})
   projects=(${(f)"$(tmuxinator completions start)"})
 
   if (( CURRENT == 2 )); then


### PR DESCRIPTION
`tmuxinator commands zsh` causes: 

    ERROR: "tmuxinator commands" was called with arguments ["zsh"]

This commit removes the extra zsh commands and solves the problem.