### PR TITLE
Add post and attach config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,20 @@ pre_window: rbenv shell 2.0.0-p247
 
 These command(s) will run before any subsequent commands in all panes and windows.
 
+## Custom attachment and post commands
+
+You can set tmuxiniator to skip auto-attaching to the session by using the `attach` option.
+
+```
+attach: false
+```
+
+You can also run arbitrary commands by using the `post` option. This is useful if you want to attach to tmux in a non-standard way (e.g. for a program that makes use of tmux control mode like iTerm2).
+
+```
+post: tmux -CC attach
+```
+
 ## Passing directly to send-keys
 
 tmuxinator passes commands directly to send keys. This differs from simply chaining commands together using `&&` or `;`, in that

--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -21,6 +21,12 @@ root: ~/
 # Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
 # startup_window: logs
 
+# Controls whether the tmux session should be attached to automatically. Defaults to true.
+# attach: false
+
+# Runs after everything. Use it to attach to tmux with custom options etc.
+# post: tmux -CC attach -t <%= name %>
+
 windows:
   - editor:
       layout: main-vertical

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -64,8 +64,12 @@ if [ "$?" -eq 1 ]; then
   <%= tmux %> select-window -t <%= startup_window %>
 fi
 
-if [ -z "$TMUX" ]; then
-  <%= tmux %> -u attach-session -t <%= name %>
-else
-  <%= tmux %> -u switch-client -t <%= name %>
-fi
+<%- if attach? -%>
+  if [ -z "$TMUX" ]; then
+    <%= tmux %> -u attach-session -t <%= name %>
+  else
+    <%= tmux %> -u switch-client -t <%= name %>
+  fi
+<%- end -%>
+
+<%= post %>

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -55,6 +55,23 @@ module Tmuxinator
       end
     end
 
+    def attach
+      attach = true
+      if !yaml["attach"].nil?
+        attach = yaml["attach"]
+      end
+      attach
+    end
+
+    def post
+      post_config = yaml["post"]
+      if post_config.is_a?(Array)
+        post_config.join("; ")
+      else
+        post_config
+      end
+    end
+
     def tmux
       "#{tmux_command}#{tmux_options}#{socket}"
     end
@@ -113,6 +130,10 @@ module Tmuxinator
 
     def name?
       !name.nil?
+    end
+
+    def attach?
+      !!attach
     end
 
     def window(i)


### PR DESCRIPTION
This (partially) solves https://github.com/tmuxinator/tmuxinator/issues/231 and adds a config setting for optionally attaching/switching to sessions.

For me this is useful since I use iTerm2 which has tmux integration that works when using tmux's control mode. So now I can set my config like this:
```
attach: false
post: tmux -CC attach
```
I tried to use just `post` and call detach there, but adding anything after the attach/switch in the template means that it won't run until the user exits the session. If there's a better solution that would just use the `post` setting, I'd be happy to remove `attach`.

I've been looking for this for a while since it's annoying to have to start a tmux session, detach, then reattach using -CC manually every time.