### PR TITLE
Search config files in sub directories of config root

### DIFF
--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -57,8 +57,8 @@ module Tmuxinator
       end
 
       def configs
-        Dir["#{Tmuxinator::Config.root}/*.yml"].sort.map do |path|
-          File.basename(path, ".yml")
+        Dir["#{Tmuxinator::Config.root}/**/*.yml"].sort.map do |path|
+          path.gsub("#{Tmuxinator::Config.root}/", "").gsub(".yml", "")
         end
       end
 


### PR DESCRIPTION
Fix completion to search in sub directory of `~/.tmuxinator` (or any other root dir for config)

It is intended to provides path from root dir instead of basename to show it in completion suggestions.

Might help for #123 (#111)