### PR TITLE
Doens't throw error when project file doesn't specify name

### DIFF
--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -31,7 +31,7 @@ module Tmuxinator
 
     def name
       name = yaml["project_name"] || yaml["name"]
-      name.shellescape
+      name.blank? ? nil : name.shellescape
     end
 
     def pre

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -22,4 +22,12 @@ FactoryGirl.define do
 
     initialize_with { Tmuxinator::Project.new(file) }
   end
+
+  factory :noname_project, :class => Tmuxinator::Project do
+    transient do
+      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/noname.yml")}")) }
+    end
+
+    initialize_with { Tmuxinator::Project.new(file) }
+  end
 end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -4,6 +4,7 @@ describe Tmuxinator::Project do
   let(:project) { FactoryGirl.build(:project) }
   let(:project_with_deprecations) { FactoryGirl.build(:project_with_deprecations) }
   let(:wemux_project) { FactoryGirl.build(:wemux_project) }
+  let(:noname_project) { FactoryGirl.build(:noname_project) }
 
   describe "#initialize" do
     context "valid yaml" do
@@ -51,6 +52,12 @@ describe Tmuxinator::Project do
         expect(project_with_deprecations.root).to include("test")
       end
     end
+
+    context "without root" do
+      it "doesn't throw an error" do
+        expect{noname_project.root}.to_not raise_error
+      end
+    end
   end
 
   describe "#name" do
@@ -69,6 +76,12 @@ describe Tmuxinator::Project do
     context "wemux" do
       it "is wemux" do
         expect(wemux_project.name).to eq "wemux"
+      end
+    end
+
+    context "without name" do
+      it "displays error message" do
+        expect{noname_project.name}.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
the `project.rb#name` function forgot to check for nil
adds a `.blank` check similarly to how `#root` works
Adds a failing test case
Adds a test case for the same behavior for `#root` (which already works)
Fixes #302