### PR TITLE
292 nameless window option

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -14,7 +14,7 @@ if [ "$?" -eq 1 ]; then
 
   # Create the session and the first window. Manually switch to root
   # directory if required to support tmux < 1.9
-  TMUX= <%= tmux %> new-session -d -s <%= name %> -n <%= windows.first.name %>
+  TMUX= <%= tmux_new_session_command %>
   <% if windows.first.root? %>
   <%= windows.first.tmux_window_command_prefix %> <%= "cd #{windows.first.root}".shellescape %> C-m
   <% end %>

--- a/lib/tmuxinator/assets/wemux_template.erb
+++ b/lib/tmuxinator/assets/wemux_template.erb
@@ -8,7 +8,7 @@ if [ "$?" -eq 127 ]; then
   <%= pre %>
 
   # Create the session and the first window.
-  TMUX= <%= tmux %> new-session -d -s <%= name %> -n <%= windows.first.name %>
+  TMUX= <%= tmux_new_session_command %>
 
   # Set the default path.
   <%- if root? -%>

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -188,6 +188,10 @@ module Tmuxinator
       "#{tmux} start-server\\; show-option -g"
     end
 
+    def tmux_new_session_command
+      "#{ tmux } new-session -d -s #{ name } -n #{ windows.first.name }"
+    end
+
     private
 
     def tmux_config

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -21,7 +21,7 @@ module Tmuxinator
       @force_detach = options[:force_detach]
 
       raise "Cannot force_attach and force_detach at the same time" if @force_attach && @force_detach
-      
+
       load_wemux_overrides if wemux?
     end
 
@@ -189,7 +189,7 @@ module Tmuxinator
     end
 
     def tmux_new_session_command
-      "#{ tmux } new-session -d -s #{ name } -n #{ windows.first.name }"
+      "#{ tmux } new-session -d -s #{ name } #{ windows.first.tmux_window_name_option }"
     end
 
     private

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -86,7 +86,7 @@ module Tmuxinator
 
     def tmux_new_window_command
       path = root? ? "#{Tmuxinator::Config.default_path_option} #{root}" : nil
-      "#{project.tmux} new-window #{path} -t #{tmux_window_target} -n #{name}"
+      "#{project.tmux} new-window #{path} -t #{tmux_window_target} #{tmux_window_name_option}"
     end
 
     def tmux_layout_command

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -80,6 +80,10 @@ module Tmuxinator
       "#{project.tmux} send-keys -t #{project.name}:#{index + project.base_index}"
     end
 
+    def tmux_window_name_option
+      name ? "-n #{name}" : ""
+    end
+
     def tmux_new_window_command
       path = root? ? "#{Tmuxinator::Config.default_path_option} #{root}" : nil
       "#{project.tmux} new-window #{path} -t #{tmux_window_target} -n #{name}"

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -53,4 +53,12 @@ FactoryGirl.define do
 
     initialize_with { Tmuxinator::Project.new(file) }
   end
+
+  factory :nameless_window_project, :class => Tmuxinator::Project do
+    transient do
+      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/nameless_window.yml")}")) }
+    end
+
+    initialize_with { Tmuxinator::Project.new(file) }
+  end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,62 +1,65 @@
+def yaml_load(file)
+  YAML.load(File.read(File.expand_path(file)))
+end
 FactoryGirl.define do
-  factory :project, :class => Tmuxinator::Project do
+  factory :project, class: Tmuxinator::Project do
     transient do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/sample.yml")}")) }
+      file { yaml_load('spec/fixtures/sample.yml') }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }
   end
 
-  factory :project_with_force_attach, :class => Tmuxinator::Project do
+  factory :project_with_force_attach, class: Tmuxinator::Project do
     transient do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/detach.yml")}")) }
+      file { yaml_load('spec/fixtures/detach.yml') }
     end
 
-    initialize_with { Tmuxinator::Project.new(file, {:force_attach => true}) }
+    initialize_with { Tmuxinator::Project.new(file, force_attach: true) }
   end
 
-  factory :project_with_force_detach, :class => Tmuxinator::Project do
+  factory :project_with_force_detach, class: Tmuxinator::Project do
     transient do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/detach.yml")}")) }
+      file { yaml_load('spec/fixtures/detach.yml') }
     end
-    initialize_with { Tmuxinator::Project.new(file, {:force_detach => true}) }
+    initialize_with { Tmuxinator::Project.new(file, force_detach: true) }
   end
 
-  factory :project_with_custom_name, :class => Tmuxinator::Project do
+  factory :project_with_custom_name, class: Tmuxinator::Project do
     transient do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/sample.yml")}")) }
-    end
-
-    initialize_with { Tmuxinator::Project.new(file, {:custom_name => "custom"}) }
-  end
-
-  factory :project_with_deprecations, :class => Tmuxinator::Project do
-    transient do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/sample.deprecations.yml")}")) }
+      file { yaml_load('spec/fixtures/sample.yml') }
     end
 
-    initialize_with { Tmuxinator::Project.new(file) }
+    initialize_with { Tmuxinator::Project.new(file, custom_name: "custom") }
   end
 
-  factory :wemux_project, :class => Tmuxinator::Project do
+  factory :project_with_deprecations, class: Tmuxinator::Project do
     transient do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/sample_wemux.yml")}")) }
+      file { yaml_load('spec/fixtures/sample.deprecations.yml') }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }
   end
 
-  factory :noname_project, :class => Tmuxinator::Project do
+  factory :wemux_project, class: Tmuxinator::Project do
     transient do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/noname.yml")}")) }
+      file { yaml_load('spec/fixtures/sample_wemux.yml') }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }
   end
 
-  factory :nameless_window_project, :class => Tmuxinator::Project do
+  factory :noname_project, class: Tmuxinator::Project do
     transient do
-      file { YAML.load(File.read("#{File.expand_path("spec/fixtures/nameless_window.yml")}")) }
+      file { yaml_load('spec/fixtures/noname.yml') }
+    end
+
+    initialize_with { Tmuxinator::Project.new(file) }
+  end
+
+  factory :nameless_window_project, class: Tmuxinator::Project do
+    transient do
+      file { yaml_load('spec/fixtures/nameless_window.yml') }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -4,7 +4,7 @@ end
 FactoryGirl.define do
   factory :project, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/sample.yml') }
+      file { yaml_load("spec/fixtures/sample.yml") }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }
@@ -12,7 +12,7 @@ FactoryGirl.define do
 
   factory :project_with_force_attach, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/detach.yml') }
+      file { yaml_load("spec/fixtures/detach.yml") }
     end
 
     initialize_with { Tmuxinator::Project.new(file, force_attach: true) }
@@ -20,14 +20,14 @@ FactoryGirl.define do
 
   factory :project_with_force_detach, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/detach.yml') }
+      file { yaml_load("spec/fixtures/detach.yml") }
     end
     initialize_with { Tmuxinator::Project.new(file, force_detach: true) }
   end
 
   factory :project_with_custom_name, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/sample.yml') }
+      file { yaml_load("spec/fixtures/sample.yml") }
     end
 
     initialize_with { Tmuxinator::Project.new(file, custom_name: "custom") }
@@ -35,7 +35,7 @@ FactoryGirl.define do
 
   factory :project_with_deprecations, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/sample.deprecations.yml') }
+      file { yaml_load("spec/fixtures/sample.deprecations.yml") }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }
@@ -43,7 +43,7 @@ FactoryGirl.define do
 
   factory :wemux_project, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/sample_wemux.yml') }
+      file { yaml_load("spec/fixtures/sample_wemux.yml") }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }
@@ -51,7 +51,7 @@ FactoryGirl.define do
 
   factory :noname_project, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/noname.yml') }
+      file { yaml_load("spec/fixtures/noname.yml") }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }
@@ -59,7 +59,7 @@ FactoryGirl.define do
 
   factory :nameless_window_project, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/nameless_window.yml') }
+      file { yaml_load("spec/fixtures/nameless_window.yml") }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }

--- a/spec/fixtures/nameless_window.yml
+++ b/spec/fixtures/nameless_window.yml
@@ -1,0 +1,5 @@
+name: nameless_window
+root: ~/
+windows:
+  - ~: echo "this is a window with no name"
+  - other: echo "this window has a name"

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -396,17 +396,17 @@ describe Tmuxinator::Project do
     end
   end
 
-  describe 'tmux_new_session_command' do
-    context 'when first window has a name' do
-      it 'returns command to start a new detatched session' do
+  describe "tmux_new_session_command" do
+    context "when first window has a name" do
+      it "returns command to start a new detatched session" do
         expect(project.tmux_new_session_command).to eq("#{project.tmux} new-session -d -s #{ project.name } -n #{ project.windows.first.name }")
       end
     end
 
-    context 'when first window is nameless' do
+    context "when first window is nameless" do
       let(:project) { nameless_window_project }
 
-      it 'returns command to start a new detatched session without specifying a window name' do
+      it "returns command to start a new detatched session without specifying a window name" do
         expect(project.tmux_new_session_command).to eq("#{project.tmux} new-session -d -s #{ project.name } ")
       end
     end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -397,17 +397,20 @@ describe Tmuxinator::Project do
   end
 
   describe "tmux_new_session_command" do
+    let(:command) { "#{project.tmux} new-session -d -s #{ project.name } -n #{ project.windows.first.name }" }
+
     context "when first window has a name" do
       it "returns command to start a new detatched session" do
-        expect(project.tmux_new_session_command).to eq("#{project.tmux} new-session -d -s #{ project.name } -n #{ project.windows.first.name }")
+        expect(project.tmux_new_session_command).to eq command
       end
     end
 
     context "when first window is nameless" do
       let(:project) { nameless_window_project }
+      let(:command) { "#{project.tmux} new-session -d -s #{ project.name } " }
 
-      it "returns command to start a new detatched session without specifying a window name" do
-        expect(project.tmux_new_session_command).to eq("#{project.tmux} new-session -d -s #{ project.name } ")
+      it "returns command to for new detatched session without a window name" do
+        expect(project.tmux_new_session_command).to eq command
       end
     end
   end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -395,4 +395,9 @@ describe Tmuxinator::Project do
     end
   end
 
+  describe 'tmux_new_session_command' do
+    it 'returns command to start a new detatched session' do
+      expect(project.tmux_new_session_command).to eq("#{project.tmux} new-session -d -s #{ project.name } -n #{ project.windows.first.name }")
+    end
+  end
 end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -9,6 +9,7 @@ describe Tmuxinator::Project do
 
   let(:wemux_project) { FactoryGirl.build(:wemux_project) }
   let(:noname_project) { FactoryGirl.build(:noname_project) }
+  let(:nameless_window_project) { FactoryGirl.build(:nameless_window_project) }
 
   describe "#initialize" do
     context "valid yaml" do
@@ -396,8 +397,18 @@ describe Tmuxinator::Project do
   end
 
   describe 'tmux_new_session_command' do
-    it 'returns command to start a new detatched session' do
-      expect(project.tmux_new_session_command).to eq("#{project.tmux} new-session -d -s #{ project.name } -n #{ project.windows.first.name }")
+    context 'when first window has a name' do
+      it 'returns command to start a new detatched session' do
+        expect(project.tmux_new_session_command).to eq("#{project.tmux} new-session -d -s #{ project.name } -n #{ project.windows.first.name }")
+      end
+    end
+
+    context 'when first window is nameless' do
+      let(:project) { nameless_window_project }
+
+      it 'returns command to start a new detatched session without specifying a window name' do
+        expect(project.tmux_new_session_command).to eq("#{project.tmux} new-session -d -s #{ project.name } ")
+      end
     end
   end
 end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -219,5 +219,13 @@ describe Tmuxinator::Window do
         expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} #{name_part}"
       end
     end
+
+    context 'name not set' do
+      let(:window_name) { nil }
+
+      it 'does not set name option' do
+        expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} "
+      end
+    end
   end
 end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -3,9 +3,10 @@ require "spec_helper"
 describe Tmuxinator::Window do
   let(:project) { double }
   let(:panes) { ["vim", nil, "top"] }
+  let(:window_name) { "editor" }
   let(:yaml) do
     {
-      "editor" => {
+      window_name => {
         "pre" => ["echo 'I get run in each pane.  Before each pane command!'", nil],
         "layout" => "main-vertical",
         "panes" => panes
@@ -154,6 +155,24 @@ describe Tmuxinator::Window do
 
       it "returns an empty array" do
         expect(window.commands).to be_empty
+      end
+    end
+  end
+
+  describe "#name_options" do
+    context 'with a name' do
+      let(:window_name) { 'editor' }
+
+      it 'specifies name with tmux name option' do
+        expect(window.tmux_window_name_option).to eq "-n #{window_name}"
+      end
+    end
+
+    context 'without a name' do
+      let(:window_name) { nil }
+
+      it 'specifies no tmux name option' do
+        expect(window.tmux_window_name_option).to be_empty
       end
     end
   end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -180,24 +180,43 @@ describe Tmuxinator::Window do
   describe "#tmux_new_window_command" do
     let(:project) { double(:project) }
     let(:window) { Tmuxinator::Window.new(yaml, 0, project) }
+    let(:root?) { true }
+    let(:root) { "/project/tmuxinator" }
 
     before do
       allow(project).to receive_messages(
-        :name => "",
+        :name => "test",
         :tmux => "tmux",
-        :root => "/project/tmuxinator",
-        :root? => true,
+        :root => root,
+        :root? => root?,
         :base_index => 1
       )
     end
 
-    context "tmux 1.6 and below" do
-      before do
-        allow(Tmuxinator::Config).to receive_messages(:version => 1.6)
-      end
+    let(:tmux_part) { project.tmux }
+    let(:window_command_part) { "new-window" }
+    let(:name_part) { window.tmux_window_name_option }
+    let(:target_part) { "-t #{window.tmux_window_target}" }
+    let(:path_part) { "#{default_path_option} #{project.root}" }
 
-      it "specifies root path by passing default-path to tmux" do
-        expect(window.tmux_new_window_command).to include("default-path /project/tmuxinator")
+    let(:default_path_option) { '-c' }
+
+    before do
+      allow(Tmuxinator::Config).to receive(:default_path_option).and_return(default_path_option)
+    end
+
+    it 'contstructs window command with path, target, and name options' do
+      expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} #{name_part}"
+    end
+
+    context 'root not set' do
+      let(:root?) { false }
+      let(:root) { nil }
+
+      let(:path_part) { nil }
+
+      it 'has an extra space instead of path_part' do
+        expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} #{name_part}"
       end
     end
   end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -160,18 +160,18 @@ describe Tmuxinator::Window do
   end
 
   describe "#name_options" do
-    context 'with a name' do
-      let(:window_name) { 'editor' }
+    context "with a name" do
+      let(:window_name) { "editor" }
 
-      it 'specifies name with tmux name option' do
+      it "specifies name with tmux name option" do
         expect(window.tmux_window_name_option).to eq "-n #{window_name}"
       end
     end
 
-    context 'without a name' do
+    context "without a name" do
       let(:window_name) { nil }
 
-      it 'specifies no tmux name option' do
+      it "specifies no tmux name option" do
         expect(window.tmux_window_name_option).to be_empty
       end
     end
@@ -205,25 +205,25 @@ describe Tmuxinator::Window do
       allow(Tmuxinator::Config).to receive(:default_path_option).and_return(default_path_option)
     end
 
-    it 'contstructs window command with path, target, and name options' do
+    it "contstructs window command with path, target, and name options" do
       expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} #{name_part}"
     end
 
-    context 'root not set' do
+    context "root not set" do
       let(:root?) { false }
       let(:root) { nil }
 
       let(:path_part) { nil }
 
-      it 'has an extra space instead of path_part' do
+      it "has an extra space instead of path_part" do
         expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} #{name_part}"
       end
     end
 
-    context 'name not set' do
+    context "name not set" do
       let(:window_name) { nil }
 
-      it 'does not set name option' do
+      it "does not set name option" do
         expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} "
       end
     end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -194,19 +194,20 @@ describe Tmuxinator::Window do
     end
 
     let(:tmux_part) { project.tmux }
-    let(:window_command_part) { "new-window" }
+    let(:window_part) { "new-window" }
     let(:name_part) { window.tmux_window_name_option }
     let(:target_part) { "-t #{window.tmux_window_target}" }
-    let(:path_part) { "#{default_path_option} #{project.root}" }
+    let(:path_part) { "#{path_option} #{project.root}" }
 
-    let(:default_path_option) { '-c' }
+    let(:path_option) { "-c" }
+    let(:full_command) { "#{tmux_part} #{window_part} #{path_part} #{target_part} #{name_part}" }
 
     before do
-      allow(Tmuxinator::Config).to receive(:default_path_option).and_return(default_path_option)
+      allow(Tmuxinator::Config).to receive(:default_path_option) { path_option }
     end
 
     it "contstructs window command with path, target, and name options" do
-      expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} #{name_part}"
+      expect(window.tmux_new_window_command).to eq full_command
     end
 
     context "root not set" do
@@ -216,15 +217,16 @@ describe Tmuxinator::Window do
       let(:path_part) { nil }
 
       it "has an extra space instead of path_part" do
-        expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} #{name_part}"
+        expect(window.tmux_new_window_command).to eq full_command
       end
     end
 
     context "name not set" do
       let(:window_name) { nil }
+      let(:full_command) { "#{tmux_part} #{window_part} #{path_part} #{target_part} " }
 
       it "does not set name option" do
-        expect(window.tmux_new_window_command).to eq "#{tmux_part} #{window_command_part} #{path_part} #{target_part} "
+        expect(window.tmux_new_window_command).to eq full_command
       end
     end
   end


### PR DESCRIPTION
Requested in issue #292 and #174.

Adds ability to create windows without a name, by using any valid yaml null key:

```yaml
name: test
root: ~/
windows:
  - ~: echo "this is a nameless window"
  - null: echo "me too"
  - Null: echo "me too"
  - NULL: echo "me too"
  - named_window: echo "this window has a name"
```

The benefit is that nameless windows use tmux's default automatic-rename behavior, meaning the displayed window name changes based on the currently running process in that window (vim, bash, tig, etc).

Let me know if I can make any changes to make this more consistent for the project.  Also, before this is merged I would like to add a note in either the README or the sample.yml file.  Please let me know where would be most appropriate.