### PR TITLE
Use SHELL from env

### DIFF
--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -123,11 +123,11 @@ module Tmuxinator
           STDIN.getc
         end
 
-        Kernel.exec(project.render)
+        Kernel.exec(ENV["SHELL"] || "/bin/sh", "-c", project.render)
       end
 
       def kill_project(project)
-        Kernel.exec(project.tmux_kill_session_command)
+        Kernel.exec(ENV["SHELL"] || "/bin/sh", "-c", project.tmux_kill_session_command)
       end
     end
 

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -282,7 +282,7 @@ module Tmuxinator
     def extract_tmux_config
       options_hash = {}
 
-      options_string = `#{show_tmux_options}`
+      options_string = IO.popen([ENV["SHELL"] || "/bin/sh", "-c", show_tmux_options]).read
       options_string.encode!("UTF-8", invalid: :replace)
       options_string.split("\n").map do |entry|
         key, value = entry.split("\s")


### PR DESCRIPTION
This is a temporary fix of #253 for me, since this patch will allow to use bash
process substitution to extend tmuxinator:

```
tmux_options: -f <(echo set -g history-limit 1000)
```
