### PR TITLE
#192 - tmuxinator commands should return non zero exit status on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ windows:
 The windows option allows the specification of any number of tmux windows. Each window is denoted by a YAML array entry, followed by a name
 and command to be run.
 
-```
+```yaml
 windows:
   - editor: vim
 ```
@@ -132,7 +132,7 @@ windows:
 
 An optional root option can be specified per window:
 
-```
+```yaml
 name: test
 root: ~/projects/company
 
@@ -170,7 +170,7 @@ or [specify your own](http://stackoverflow.com/a/9976282/183537).
 
 To use tmuxinator with rbenv, RVM, NVM etc, use the `pre_window` option.
 
-```
+```yaml
 pre_window: rbenv shell 2.0.0-p247
 ```
 
@@ -180,13 +180,13 @@ These command(s) will run before any subsequent commands in all panes and window
 
 You can set tmuxiniator to skip auto-attaching to the session by using the `attach` option.
 
-```
+```yaml
 attach: false
 ```
 
 You can also run arbitrary commands by using the `post` option. This is useful if you want to attach to tmux in a non-standard way (e.g. for a program that makes use of tmux control mode like iTerm2).
 
-```
+```yaml
 post: tmux -CC attach
 ```
 
@@ -198,7 +198,7 @@ SSH for example.
 
 To support this both the window and pane options can take an array as an argument:
 
-```
+```yaml
 name: sample
 root: ~/
 
@@ -219,7 +219,7 @@ windows:
 
 Project files support [ERB](https://en.wikipedia.org/wiki/ERuby#erb) for reusability across environments. Eg:
 
-```
+```yaml
 root: <%= ENV["MY_CUSTOM_DIR"] %>
 ```
 

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -1,5 +1,12 @@
 module Tmuxinator
   class Cli < Thor
+
+    # By default, Thor returns exit(0) when an error occurs.
+    # Please see: https://github.com/tmuxinator/tmuxinator/issues/192
+    def self.exit_on_failure?
+      true
+    end
+
     include Tmuxinator::Util
 
     COMMANDS = {

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -45,7 +45,7 @@ module Tmuxinator
 
     def name
       name = custom_name || yaml["project_name"] || yaml["name"]
-      name.blank? ? nil : name.shellescape
+      name.blank? ? nil : name.to_s.shellescape
     end
 
     def pre

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
 
   factory :project_with_number_as_name, class: Tmuxinator::Project do
     transient do
-      file { yaml_load('spec/fixtures/sample_number_as_name.yml') }
+      file { yaml_load("spec/fixtures/sample_number_as_name.yml") }
     end
 
     initialize_with { Tmuxinator::Project.new(file) }

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -33,6 +33,14 @@ FactoryGirl.define do
     initialize_with { Tmuxinator::Project.new(file, custom_name: "custom") }
   end
 
+  factory :project_with_number_as_name, class: Tmuxinator::Project do
+    transient do
+      file { yaml_load('spec/fixtures/sample_number_as_name.yml') }
+    end
+
+    initialize_with { Tmuxinator::Project.new(file) }
+  end
+
   factory :project_with_deprecations, class: Tmuxinator::Project do
     transient do
       file { yaml_load("spec/fixtures/sample.deprecations.yml") }

--- a/spec/fixtures/sample_number_as_name.yml
+++ b/spec/fixtures/sample_number_as_name.yml
@@ -1,0 +1,41 @@
+# ~/.tmuxinator/sample_number_as_name.yml
+# you can make as many tabs as you wish...
+
+name: 222
+root: ~/test
+socket_name: foo # Remove to use default socket
+pre: sudo /etc/rc.d/mysqld start # Runs before everything
+pre_window: rbenv shell 2.0.0-p247 # Runs in each tab and pane
+tmux_options: -f ~/.tmux.mac.conf # Pass arguments to tmux
+tmux_detached: false
+windows:
+  - editor:
+      pre:
+        - echo "I get run in each pane, before each pane command!"
+        -
+      layout: main-vertical
+      panes:
+        - vim
+        - #empty, will just run plain bash
+        - top
+        - pane_with_multiple_commands:
+            - ssh server
+            - echo "Hello"
+  - shell:
+    - git pull
+    - git merge
+  - guard:
+      layout: tiled
+      pre:
+        - echo "I get run in each pane."
+        - echo "Before each pane command!"
+      panes:
+        -
+        - #empty, will just run plain bash
+        -
+  - database: bundle exec rails db
+  - server: bundle exec rails s
+  - logs: tail -f log/development.log
+  - console: bundle exec rails c
+  - capistrano:
+  - server: ssh user@example.com

--- a/spec/fixtures/sample_number_as_name.yml
+++ b/spec/fixtures/sample_number_as_name.yml
@@ -1,41 +1,5 @@
 # ~/.tmuxinator/sample_number_as_name.yml
-# you can make as many tabs as you wish...
 
 name: 222
-root: ~/test
-socket_name: foo # Remove to use default socket
-pre: sudo /etc/rc.d/mysqld start # Runs before everything
-pre_window: rbenv shell 2.0.0-p247 # Runs in each tab and pane
-tmux_options: -f ~/.tmux.mac.conf # Pass arguments to tmux
-tmux_detached: false
 windows:
-  - editor:
-      pre:
-        - echo "I get run in each pane, before each pane command!"
-        -
-      layout: main-vertical
-      panes:
-        - vim
-        - #empty, will just run plain bash
-        - top
-        - pane_with_multiple_commands:
-            - ssh server
-            - echo "Hello"
-  - shell:
-    - git pull
-    - git merge
-  - guard:
-      layout: tiled
-      pre:
-        - echo "I get run in each pane."
-        - echo "Before each pane command!"
-      panes:
-        -
-        - #empty, will just run plain bash
-        -
-  - database: bundle exec rails db
-  - server: bundle exec rails s
-  - logs: tail -f log/development.log
-  - console: bundle exec rails c
-  - capistrano:
-  - server: ssh user@example.com
+  - number: echo number as name fixture

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -266,4 +266,16 @@ describe Tmuxinator::Cli do
       capture_io { cli.start }
     end
   end
+
+  context "exit status" do
+    before do
+      ARGV.replace(["non-existent-command"])
+    end
+
+    it "returns a non-zero status when an error occurs" do
+      expect { capture_io { cli.start } }.to raise_error(SystemExit) do |e|
+        expect(e.status).to eq 1
+      end
+    end
+  end
 end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -3,7 +3,9 @@ require "spec_helper"
 describe Tmuxinator::Project do
   let(:project) { FactoryGirl.build(:project) }
   let(:project_with_custom_name) { FactoryGirl.build(:project_with_custom_name) }
-  let(:project_with_number_as_name) { FactoryGirl.build(:project_with_number_as_name) }
+  let(:project_with_number_as_name) {
+    FactoryGirl.build(:project_with_number_as_name)
+  }
   let(:project_with_deprecations) { FactoryGirl.build(:project_with_deprecations) }
   let(:project_with_force_attach) { FactoryGirl.build(:project_with_force_attach) }
   let(:project_with_force_detach) { FactoryGirl.build(:project_with_force_detach) }

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Tmuxinator::Project do
   let(:project) { FactoryGirl.build(:project) }
   let(:project_with_custom_name) { FactoryGirl.build(:project_with_custom_name) }
+  let(:project_with_number_as_name) { FactoryGirl.build(:project_with_number_as_name) }
   let(:project_with_deprecations) { FactoryGirl.build(:project_with_deprecations) }
   let(:project_with_force_attach) { FactoryGirl.build(:project_with_force_attach) }
   let(:project_with_force_detach) { FactoryGirl.build(:project_with_force_detach) }
@@ -96,6 +97,13 @@ describe Tmuxinator::Project do
     context "without name" do
       it "displays error message" do
         expect{noname_project.name}.to_not raise_error
+      end
+    end
+
+    context "as number" do
+      it "will gracefully handle a name given as a number" do
+        rendered = project_with_number_as_name
+        expect(rendered.name.to_i).to_not equal 0
       end
     end
   end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -3,9 +3,9 @@ require "spec_helper"
 describe Tmuxinator::Project do
   let(:project) { FactoryGirl.build(:project) }
   let(:project_with_custom_name) { FactoryGirl.build(:project_with_custom_name) }
-  let(:project_with_number_as_name) {
+  let(:project_with_number_as_name) do
     FactoryGirl.build(:project_with_number_as_name)
-  }
+  end
   let(:project_with_deprecations) { FactoryGirl.build(:project_with_deprecations) }
   let(:project_with_force_attach) { FactoryGirl.build(:project_with_force_attach) }
   let(:project_with_force_detach) { FactoryGirl.build(:project_with_force_detach) }


### PR DESCRIPTION
Configure Thor to return `exit(1)` on error, instead of `exit(0)` which it does by default.

- [exit_on_failure?](https://github.com/erikhuda/thor/blob/f0c2166534e122636f5ce04d61885736ef605617/lib/thor/base.rb#L622-L625) definition in Thor::Base
- discussion about this "feature" in [Thor #244](https://github.com/erikhuda/thor/issues/244).