### PR TITLE
#192 - Set Thor to return non-zero (1) exit status on error

### DIFF
--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -1,5 +1,12 @@
 module Tmuxinator
   class Cli < Thor
+
+    # By default, Thor returns exit(0) when an error occurs.
+    # Please see: https://github.com/tmuxinator/tmuxinator/issues/192
+    def self.exit_on_failure?
+      true
+    end
+
     include Tmuxinator::Util
 
     COMMANDS = {

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -1,6 +1,5 @@
 module Tmuxinator
   class Cli < Thor
-
     # By default, Thor returns exit(0) when an error occurs.
     # Please see: https://github.com/tmuxinator/tmuxinator/issues/192
     def self.exit_on_failure?

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -397,4 +397,16 @@ describe Tmuxinator::Cli do
       it_should_behave_like :a_proper_project
     end
   end
+
+  context "exit status" do
+    before do
+      ARGV.replace(["non-existent-command"])
+    end
+
+    it "returns a non-zero status when an error occurs" do
+      expect { capture_io { cli.start } }.to raise_error(SystemExit) do |e|
+        expect(e.status).to eq 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
Configure Thor to return `exit(1)` on error, instead of `exit(0)` which it does by default.

- [exit_on_failure?](https://github.com/erikhuda/thor/blob/f0c2166534e122636f5ce04d61885736ef605617/lib/thor/base.rb#L622-L625) definition in Thor::Base
- discussion about this "feature" in [Thor #244](https://github.com/erikhuda/thor/issues/244).