### PR TITLE
347 - prevent tmux from opening sessions using prefixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem "coveralls", "~> 0.7"
 gem "awesome_print", "~> 1.2"
 gem "pry", "~> 0.10"
 gem "factory_girl", "~> 4.5"
-gem "rubocop", "~> 0.34", require: false
+gem "rubocop", "0.35.1", require: false

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -4,7 +4,7 @@
 unset RBENV_VERSION
 unset RBENV_DIR
 
-<%= tmux %> start-server\; has-session -t <%= name %> 2>/dev/null
+<%= tmux %> start-server\; has-session = <%= name %> 2>/dev/null
 
 if [ "$?" -eq 1 ]; then
   cd <%= root || "." %>

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -54,7 +54,7 @@ describe Tmuxinator::Project do
 
     # Please see: https://github.com/tmuxinator/tmuxinator/issues/347
     context "open sessions" do
-      it "uses 'has-session =' to avoid overeager matches on open session names" do
+      it "uses 'has-session =' to avoid matching open session name prefixes" do
         output = project.render
         expect(output).to match %r{has-session =}
       end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -51,6 +51,14 @@ describe Tmuxinator::Project do
         expect(rendered).to_not include("sample")
       end
     end
+
+    # Please see: https://github.com/tmuxinator/tmuxinator/issues/347
+    context "open sessions" do
+      it "uses 'has-session =' to avoid overeager matches on open session names" do
+        output = project.render
+        expect(output).to match %r{has-session =}
+      end
+    end
   end
 
   describe "#windows" do


### PR DESCRIPTION
Fixes #347, wherein calling `mux project` would attach to an existing session called `project-test`.

I've been scratching my head about how to write a failing test that this PR will make pass, but haven't come up with anything yet. Does anyone have any ideas?

Also, HT to @nicm for suggesting the use of `has-session = ...` in [Tmux issue #201](https://github.com/tmux/tmux/issues/201).