### PR TITLE
Tests for edit-delete fix

### DIFF
--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -72,16 +72,16 @@ module Tmuxinator
     end
 
     no_commands do
-      def find_project_file(name, local=false)
+      def find_project_file(name, local = false)
         path = if local
                  Tmuxinator::Config::LOCAL_DEFAULT
                else
                  Tmuxinator::Config.default_project(name)
                end
-        unless File.exists?(path)
-          generate_project_file(name, path)
-        else
+        if File.exists?(path)
           path
+        else
+          generate_project_file(name, path)
         end
       end
 

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
Builds on https://github.com/tmuxinator/tmuxinator/pull/358

- Refactors `Tmuxinator::Cli#new` a bit and incorporates change from https://github.com/tmuxinator/tmuxinator/pull/358 on top of it
- Adds tests for refactorings
- Adds test for `mux edit #{project}` where the project file already exists

Per [PR 358](https://github.com/tmuxinator/tmuxinator/pull/358), fixes [Issue 354](https://github.com/tmuxinator/tmuxinator/issues/354)