### PR TITLE
Fixes SimpleCov syntax breakage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem "rake", "~> 10.4"
 gem "rspec", "~> 3.3"
-gem "simplecov", "~> 0.9"
+gem "simplecov", "~> 0.11.0"
 gem "coveralls", "~> 0.7"
 gem "awesome_print", "~> 1.2"
 gem "pry", "~> 0.10"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,11 @@ require "coveralls"
 require "simplecov"
 require "pry"
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(formatters)
 SimpleCov.start do
   add_filter "vendor/cache"
 end


### PR DESCRIPTION
- Changes spec_helper to use new syntax for 0.11.0
- Specify simplecov version to only apply patch builds; i.e. ~> 0.11.0