### PR TITLE
Adds a default argument for a --default [filename].yml to be used as the

### DIFF
--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -87,7 +87,7 @@ module Tmuxinator
       end
 
       def generate_project_file(name, path)
-        default = options[:default].to_s != '' ? options[:default] : "default"
+        default = options[:default].to_s != "" ? options[:default] : "default"
         template = Tmuxinator::Config.default(default)
         content = File.read(template)
         erb = Erubis::Eruby.new(content).result(binding)

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -57,6 +57,7 @@ module Tmuxinator
     end
 
     desc "new [PROJECT]", COMMANDS[:new]
+    option :default
     map "open" => :new
     map "edit" => :new
     map "o" => :new
@@ -86,8 +87,9 @@ module Tmuxinator
       end
 
       def generate_project_file(name, path)
-        template = Tmuxinator::Config.default? ? :default : :sample
-        content = File.read(Tmuxinator::Config.send(template.to_sym))
+        default = options[:default].to_s != '' ? options[:default] : "default"
+        template = Tmuxinator::Config.default(default)
+        content = File.read(template)
         erb = Erubis::Eruby.new(content).result(binding)
         File.open(path, "w") { |f| f.write(erb) }
         path

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -14,12 +14,11 @@ module Tmuxinator
         asset_path "sample.yml"
       end
 
-      def default
-        "#{ENV['HOME']}/.tmuxinator/default.yml"
-      end
-
-      def default?
-        exists?("default")
+      def default(filename)
+        if exists? (filename)
+          return "#{ENV['HOME']}/.tmuxinator/#{filename}.yml"
+        end
+        sample
       end
 
       def installed?

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -15,6 +15,7 @@ describe Tmuxinator::Config do
 
   describe "#default" do
     it "gets the path of the default config" do
+      allow(Tmuxinator::Config).to receive(:exists?).and_return(true)
       expect(Tmuxinator::Config.default("default")).to include("default.yml")
     end
     it "maps the path of sample if default fails" do

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -21,7 +21,6 @@ describe Tmuxinator::Config do
     it "maps the path of sample if default fails" do
       expect(Tmuxinator::Config.default("notafile")).to include("sample.yml")
     end
-
   end
 
   describe "#default_path_option" do

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -15,8 +15,12 @@ describe Tmuxinator::Config do
 
   describe "#default" do
     it "gets the path of the default config" do
-      expect(Tmuxinator::Config.default).to include("default.yml")
+      expect(Tmuxinator::Config.default("default")).to include("default.yml")
     end
+    it "maps the path of sample if default fails" do
+      expect(Tmuxinator::Config.default("notafile")).to include("sample.yml")
+    end
+
   end
 
   describe "#default_path_option" do
@@ -37,34 +41,6 @@ describe Tmuxinator::Config do
 
       it "returns default-path" do
         expect(Tmuxinator::Config.default_path_option).to eq "default-path"
-      end
-    end
-  end
-
-  describe "#default?" do
-    let(:root) { Tmuxinator::Config.root }
-    let(:local_default) { Tmuxinator::Config::LOCAL_DEFAULT }
-    let(:proj_default) { Tmuxinator::Config.default }
-
-    context "when the file exists" do
-      before do
-        allow(File).to receive(:exists?).with(local_default) { false }
-        allow(File).to receive(:exists?).with(proj_default) { true }
-      end
-
-      it "returns true" do
-        expect(Tmuxinator::Config.default?).to be_truthy
-      end
-    end
-
-    context "when the file doesn't exist" do
-      before do
-        allow(File).to receive(:exists?).with(local_default) { false }
-        allow(File).to receive(:exists?).with(proj_default) { false }
-      end
-
-      it "returns true" do
-        expect(Tmuxinator::Config.default?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
template.

The use case for this is when having muliple simular projects in your
daily tasks that can't inherit from only one template type.

The approach used was to dry up code by removing default? which is
essentially exists?(filename) but without accepting the argument.
Therefore this method could be removed. default(filename) was adjusted
to accept a filename parameter which still defaults to "default" if one
isn't passed.  Finally if filename and default do not exist then the
sample method should be returned.  This also removed the need for
calling to_sym as the default already returns the appropriate file
path.
