### PR TITLE
Fix issue with creating panes with custom layout

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -60,9 +60,10 @@ if [ "$?" -eq 1 ]; then
         <% unless pane.last? %>
   <%= pane.tmux_split_command %>
         <% end %>
-  <%= window.tmux_layout_command %>
+  <%= window.tmux_tiled_layout_command %>
       <% end %>
 
+  <%= window.tmux_layout_command %>
   <%= window.tmux_select_first_pane %>
     <% end %>
   <% end %>

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -95,6 +95,10 @@ module Tmuxinator
       "#{project.tmux} new-window #{path} -t #{tmux_window_target} #{tmux_window_name_option}"
     end
 
+    def tmux_tiled_layout_command
+      "#{project.tmux} select-layout -t #{tmux_window_target} tiled"
+    end
+
     def tmux_layout_command
       "#{project.tmux} select-layout -t #{tmux_window_target} #{layout}"
     end


### PR DESCRIPTION
- When not using a built in layout, applying the layout after every pane
  is created causes issues, and the pane cannot be created
- It should be sufficient to apply the tiled layout (which should
  distribute them in a space efficent manner) after each pane is
  created, and finally apply the desired layout after all panes are
  created.
- Fixes #374 