### PR TITLE
Downgraded simplecov for coveralls compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem "rake", "~> 10.4"
 gem "rspec", "~> 3.3"
-gem "simplecov", "~> 0.11.0"
+gem "simplecov", "~> 0.10.0"
 gem "coveralls", "~> 0.7"
 gem "awesome_print", "~> 1.2"
 gem "pry", "~> 0.10"


### PR DESCRIPTION
On my machine, running `bundle install` resulted in Bundler complaining that our `Gemfile` asked for version 0.11.0 or simplecov, while our `Gemfile.lock` had it locked in at version 0.10.0. After trying to upgrade simplecov, it turns out that the latest version of coveralls requires the outdated version of simplecov. So I modified the Gemfile to say to use version 0.10.0, and all should be well and good.