### PR TITLE
Use `tmux -V` command for checking tmux existence

### DIFF
--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -23,7 +23,7 @@ module Tmuxinator
       end
 
       def installed?
-        Kernel.system("type tmux > /dev/null")
+        Kernel.system("tmux -V > /dev/null")
       end
 
       def version


### PR DESCRIPTION
Windows has `type` command, but it does not work the same as Unix like OS's one, it's similar to `cat` command. So, checking tmux existence failed on Windows (MSYS2) with `type` command.

`tmux -V` returns 0 when `tmux` command exists, otherwise non-0 be returned. This is equivalent of `type tmux` on Unix like OS, for checking `tmux` command existence.
