### PR TITLE
Completions: test if tmuxinator is actually on $PATH

### DIFF
--- a/completion/tmuxinator.bash
+++ b/completion/tmuxinator.bash
@@ -8,7 +8,7 @@ _tmuxinator() {
     if [ "$COMP_CWORD" -eq 1 ]; then
         local commands="$(compgen -W "$(tmuxinator commands)" -- "$word")"
         local projects="$(compgen -W "$(tmuxinator completions start)" -- "$word")"
- 
+
         COMPREPLY=( $commands $projects )
     elif [ "$COMP_CWORD" -eq 2 ]; then
         local words
@@ -21,4 +21,6 @@ _tmuxinator() {
     fi
 }
 
-complete -F _tmuxinator tmuxinator mux
+type tmuxinator 2>&1 > /dev/null && {
+    complete -F _tmuxinator tmuxinator mux
+}

--- a/completion/tmuxinator.zsh
+++ b/completion/tmuxinator.zsh
@@ -19,7 +19,9 @@ _tmuxinator() {
   return
 }
 
-_tmuxinator
+type tmuxinator 2>&1 > /dev/null && {
+  _tmuxinator
+}
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
I'm sure others carry their shell environment around as well on to machines where they don't want to install tmuxinator. As such trying to source the completion script results in the annoying message of 'tmuxinator: not found'. If I want tmuxinator, I'll install it if I need it.