### PR TITLE
Fix bash completion error

### DIFF
--- a/completion/tmuxinator.bash
+++ b/completion/tmuxinator.bash
@@ -21,6 +21,6 @@ _tmuxinator() {
     fi
 }
 
-type tmuxinator 2>&1 > /dev/null && {
+type tmuxinator &> /dev/null && {
     complete -F _tmuxinator tmuxinator mux
 }

--- a/completion/tmuxinator.zsh
+++ b/completion/tmuxinator.zsh
@@ -19,7 +19,7 @@ _tmuxinator() {
   return
 }
 
-type tmuxinator 2>&1 > /dev/null && {
+type tmuxinator &> /dev/null && {
   _tmuxinator
 }
 


### PR DESCRIPTION
By using "all output redirection", bash should no longer print the error to
console when tmuxinator is not installed. The zsh checking has been updated to
use the same method for parity.

Closes #395