### PR TITLE
Changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2
+- Bugfix for attaching to sessions by prefix when running `start`
+- Bugfix for "pane could not be created" error
+
 ## 0.7.1
 - Bugfix where `mux open` or similar would delete the contents of the file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.1
+- Bugfix where `mux open` or similar would delete the contents of the file
+
 ## 0.7.0
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+### New features
+
+- Add support for deleting multiple projects at once, using `mux delete <p1> <p2> ...`
+- Add stop command to kill tmux sessions
+
+### Bugfixes
+
+- Bugfix for issue with using numbers as window names
+- Bugfix for trying to load shell completions before checking to see if tmuxinator is installed.
+
 ## 0.7.2
 - Bugfix for attaching to sessions by prefix when running `start`
 - Bugfix for "pane could not be created" error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ should submit a Pull Request!
   require no new tests. If you are adding functionality or fixing a bug,
   we need a test!
 * Run _all_ the tests to ensure nothing else was broken. We only take pull requests with passing tests.
+* Make a note in the `CHANGELOG.md` file with a brief summary of your change under the heading "Unreleased" at the top of the file. If that heading does not exist, you should add it.
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Structure your commit messages like this:
 


### PR DESCRIPTION
This PR includes:
- Add releases v0.7.1, v0.7.2 to the changelog
- Add a note in the "CONTRIBUTING" file to suggest that contributors document their changes in the changelog

Some items were intentionally omitted from the changelog, as they were internal-facing instead of user-facing. These include:
- Test updates/fixes
- Travis CI/Rubocop/etc updates/fixes
- Contributing or similar updates

If my update to the changelog is missing anything, there are phrasing or spelling errors, or you disagree with my approach, please comment and let me know!

*P.S. Looks like it's about time for a v0.8.0 release*