### PR TITLE
Improve bash/zsh completion-setup flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bugfixes
 
 - Bugfix for issue with using numbers as window names
-- Bugfix for trying to load shell completions before checking to see if tmuxinator is installed.
+- Bugfix for zsh-completion loading throwing an error if tmuxinator is not yet available.
 - Bugfix for using `mux delete` to delete local projects
 
 ## 0.7.2
@@ -48,13 +48,13 @@
 - Fix error when no project name is provided #303
 
 ## 0.6.10
-- Interpret config file as ERB template #255 
-- Fix zsh completions #262 
-- Alias `e` to edit and `o` to open #275 
-- Fix fish completions #280 
+- Interpret config file as ERB template #255
+- Fix zsh completions #262
+- Alias `e` to edit and `o` to open #275
+- Fix fish completions #280
 - Add `startup_window` #282
-- Add per window root option #283 
-- Fix project path detection #274 
+- Add per window root option #283
+- Fix project path detection #274
 - Include completions in gemspec #270
 
 ## 0.6.9

--- a/completion/tmuxinator.bash
+++ b/completion/tmuxinator.bash
@@ -21,6 +21,4 @@ _tmuxinator() {
     fi
 }
 
-type tmuxinator 2>&1 > /dev/null && {
-    complete -F _tmuxinator tmuxinator mux
-}
+complete -F _tmuxinator tmuxinator mux

--- a/completion/tmuxinator.zsh
+++ b/completion/tmuxinator.zsh
@@ -1,5 +1,3 @@
-#compdef tmuxinator mux
-
 _tmuxinator() {
   local commands projects
   commands=(${(f)"$(tmuxinator commands zsh)"})
@@ -19,9 +17,7 @@ _tmuxinator() {
   return
 }
 
-type tmuxinator 2>&1 > /dev/null && {
-  _tmuxinator
-}
+compdef _tmuxinator tmuxinator mux
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
By removing the `tmuxinator`-existence checks and by employing the
correct completion definition functions, `tmuxinator.bash` and
`tmuxinator.zsh` can be sourced at any time, without running into errors
caused by not-yet-initialised `rvm` installations.

For `zsh`:

Previously, the first `#compdef` line was inserted that allowed
`tmuxinator.zsh` to be used within `zsh`'s completion autoloading,
however, since it seems preferable to install `tmuxinator` completion by
directly sourcing files, this autoload-related definition is no longer
necessary, and an explicit `compdef` takes its place.