### PR TITLE
Completions fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Bugfixes
+
+- Fixed broken shell completions
+
 ## 0.8.0
 ### New features
 

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -55,7 +55,7 @@ module Tmuxinator
     def completions(arg)
       if %w(start stop open copy delete).include?(arg)
         configs = Tmuxinator::Config.configs
-        say configs
+        say configs.join("\n")
       end
     end
 

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -20,12 +20,12 @@ describe Tmuxinator::Cli do
   describe "#completions" do
     before do
       ARGV.replace(["completions", "start"])
-      allow(Tmuxinator::Config).to receive_messages(configs: ["test.yml"])
+      allow(Tmuxinator::Config).to receive_messages(configs: ["test.yml", "foo.yml"])
     end
 
     it "gets completions" do
       out, _err = capture_io { cli.start }
-      expect(out).to include("test.yml")
+      expect(out).to include("test.yml\nfoo.yml")
     end
   end
 

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -20,7 +20,8 @@ describe Tmuxinator::Cli do
   describe "#completions" do
     before do
       ARGV.replace(["completions", "start"])
-      allow(Tmuxinator::Config).to receive_messages(configs: ["test.yml", "foo.yml"])
+      allow(Tmuxinator::Config).to receive_messages(configs: ["test.yml",
+                                                              "foo.yml"])
     end
 
     it "gets completions" do


### PR DESCRIPTION
The issue was that `puts` and `say` handle arrays differently. `puts`
will display each entry in the array on it's own line, but `say` will
spit out a formatted Ruby array. I rectified this issue by joining the
array with a newline, and use `say` to print it.

Closes #405 