### PR TITLE
Config.root refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Refactor Config.root
+
 ## 0.8.1
 ### Bugfixes
 

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -5,9 +5,9 @@ module Tmuxinator
 
     class << self
       def root
-        root_dir = File.expand_path("~/.tmuxinator")
-        Dir.mkdir("#{ENV['HOME']}/.tmuxinator") unless File.directory?(root_dir)
-        "#{ENV['HOME']}/.tmuxinator"
+        root_dir = File.expand_path("#{ENV['HOME']}/.tmuxinator")
+        Dir.mkdir(root_dir) unless File.directory?(root_dir)
+        root_dir
       end
 
       def sample


### PR DESCRIPTION
There were a few issues that led me to making this change:

1. there were two different string representations of the path `~/.tmuxinator` in use (`"#{ENV['HOME']}/.tmuxinator"` and `"~/.tmuxinator"`)
2. the path is available as the return value of the call to `File.expand_path`, so it'd seem to reason that only one string representation should be necessary

I looked through the history, but didn't see any reference to needing to use the different representations to support various environments/platforms. Please chime in if anyone has any insight as to why those different variations were used and/or if one should be used instead of the other in the call to `File.expand_path`.