### PR TITLE
266 initialize pane commands with yaml array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unlreased
+
+### New Features
+- Allow mulitple panes to be defined using yaml hash or array #266, #406
+
 ## 0.8.1
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unlreased
+## Unreleased
 
 ### New Features
 - Allow mulitple panes to be defined using yaml hash or array #266, #406

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -49,12 +49,8 @@ unset RBENV_DIR
         <% if pane.tab.pre %>
   <%= pane.tmux_pre_command %>
         <% end %>
-        <% if pane.multiple_commands? %>
-          <% pane.commands.each do |command| %>
+        <% pane.commands.each do |command| %>
   <%= pane.tmux_main_command(command) %>
-          <% end %>
-        <% else %>
-  <%= pane.tmux_main_command(commands.first) %>
         <% end %>
 
         <% unless pane.last? %>

--- a/lib/tmuxinator/assets/wemux_template.erb
+++ b/lib/tmuxinator/assets/wemux_template.erb
@@ -32,12 +32,8 @@ if [ "$?" -eq 127 ]; then
       <%- window.panes.each do |pane| -%>
   <%= pane.tmux_pre_window_command %>
   <%= pane.tmux_pre_command %>
-    <%- if pane.multiple_commands? %>
-          <%- pane.commands.each do |command| -%>
+        <%- pane.commands.each do |command| -%>
   <%= pane.tmux_main_command(command) %>
-          <%- end -%>
-        <%- else -%>
-  <%= pane.tmux_main_command(commands.first) %>
         <%- end -%>
 
       <%- unless pane.last? -%>

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -53,9 +53,5 @@ module Tmuxinator
     def last?
       index == tab.panes.length - 1
     end
-
-    def multiple_commands?
-      commands && commands.length > 0
-    end
   end
 end

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -34,13 +34,16 @@ module Tmuxinator
 
     def build_panes(panes_yml)
       Array(panes_yml).map.with_index do |pane_yml, index|
-        if pane_yml.is_a?(Hash)
-          pane_yml.map do |_name, commands|
-            Tmuxinator::Pane.new(index, project, self, *commands)
-          end
-        else
-          Tmuxinator::Pane.new(index, project, self, pane_yml)
-        end
+        commands =  case pane_yml
+                    when Hash
+                      pane_yml.values.first
+                    when Array
+                      pane_yml
+                    else
+                      pane_yml
+                    end
+
+        Tmuxinator::Pane.new(index, project, self, *commands)
       end.flatten
     end
 

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -99,6 +99,35 @@ describe Tmuxinator::Window do
         expect(window.panes).to be_empty
       end
     end
+
+    context "nested collections" do
+      let(:command1) { "cd /tmp/" }
+      let(:command2) { "ls" }
+
+      let(:panes) { [ "vim", nested_collection ] }
+
+      context "with nested hash" do
+        let(:nested_collection) { { pane2: [ command1, command2  ] } }
+
+        it "returns two panes in an Array" do
+          expect(window.panes).to match [
+            a_pane.with(index: 0).and_commands("vim"),
+            a_pane.with(index: 1).and_commands(command1, command2)
+          ]
+        end
+      end
+
+      context "with nested array" do
+        let(:nested_collection) { [command1, command2] }
+
+        it "returns two panes in an Array" do
+          expect(window.panes).to match [
+            a_pane.with(index: 0).and_commands("vim"),
+            a_pane.with(index: 1).and_commands(command1, command2)
+          ]
+        end
+      end
+    end
   end
 
   describe "#pre" do

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -74,7 +74,9 @@ describe Tmuxinator::Window do
       end
 
       it "returns three panes" do
-        expect(window.panes).to all be_a_pane.with(project: project, tab: window)
+        expect(window.panes).to all be_a_pane.with(
+          project: project, tab: window
+        )
 
         expect(window.panes).to match([
           a_pane.with(index: 0).and_commands("vim"),
@@ -88,7 +90,8 @@ describe Tmuxinator::Window do
       let(:panes) { "vim" }
 
       it "returns one pane in an Array" do
-        expect(window.panes.first).to be_a_pane.with(index: 0).and_commands("vim")
+        expect(window.panes.first).to be_a_pane.
+          with(index: 0).and_commands("vim")
       end
     end
 
@@ -104,10 +107,10 @@ describe Tmuxinator::Window do
       let(:command1) { "cd /tmp/" }
       let(:command2) { "ls" }
 
-      let(:panes) { [ "vim", nested_collection ] }
+      let(:panes) { ["vim", nested_collection] }
 
       context "with nested hash" do
-        let(:nested_collection) { { pane2: [ command1, command2  ] } }
+        let(:nested_collection) { { pane2: [command1, command2] } }
 
         it "returns two panes in an Array" do
           expect(window.panes).to match [

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -65,14 +65,8 @@ describe Tmuxinator::Window do
   end
 
   describe "#panes" do
-    let(:pane) { double(:pane) }
-
-    before do
-      allow(Tmuxinator::Pane).to receive_messages new: pane
-    end
-
     context "with a three element Array" do
-      let(:panes) { ["vim", nil, "top"] }
+      let(:panes) { ["vim", "ls", "top"] }
 
       it "creates three panes" do
         expect(Tmuxinator::Pane).to receive(:new).exactly(3).times
@@ -80,30 +74,26 @@ describe Tmuxinator::Window do
       end
 
       it "returns three panes" do
-        expect(window.panes).to eql [pane, pane, pane]
+        expect(window.panes).to all be_a_pane.with(project: project, tab: window)
+
+        expect(window.panes).to match([
+          a_pane.with(index: 0).and_commands("vim"),
+          a_pane.with(index: 1).and_commands("ls"),
+          a_pane.with(index: 2).and_commands("top")
+        ])
       end
     end
 
     context "with a String" do
       let(:panes) { "vim" }
 
-      it "creates one pane" do
-        expect(Tmuxinator::Pane).to receive(:new).once
-        window.panes
-      end
-
       it "returns one pane in an Array" do
-        expect(window.panes).to eql [pane]
+        expect(window.panes.first).to be_a_pane.with(index: 0).and_commands("vim")
       end
     end
 
     context "with nil" do
       let(:panes) { nil }
-
-      it "doesn't create any panes" do
-        expect(Tmuxinator::Pane).to_not receive(:new)
-        window.panes
-      end
 
       it "returns an empty Array" do
         expect(window.panes).to be_empty

--- a/spec/matchers/pane_matcher.rb
+++ b/spec/matchers/pane_matcher.rb
@@ -1,0 +1,43 @@
+RSpec::Matchers.alias_matcher :be_a_pane, :a_pane
+RSpec::Matchers.define :a_pane do |expected|
+  attr_reader :commands
+
+  match do |pane|
+    result = is_pane
+
+    result && attributes_match if @expected_attrs
+    result &&= commands_match if commands
+
+    result
+  end
+
+  failure_message do |actual|
+    return "Expected #{actual} to be a Tmuxinator::Pane" unless is_pane
+
+    msg = "Actual pane does not match expected"
+    msg << "\n  Expected commands #{@commands} but has #{actual.commands}" if @commands
+    msg << "\n  Expected pane to have attributes #{@expected_attrs}" if @expected_attrs
+  end
+
+  chain :with do |attrs|
+    @expected_attrs = attrs
+  end
+
+  chain :with_commands do |*expected|
+    @commands = expected
+  end
+  alias_method :and_commands, :with_commands
+
+  private
+  def attributes_match
+    expect(@actual).to have_attributes(@expected_attrs)
+  end
+
+  def commands_match
+    @actual.commands == commands
+  end
+
+  def is_pane
+    @actual.is_a? Tmuxinator::Pane
+  end
+end

--- a/spec/matchers/pane_matcher.rb
+++ b/spec/matchers/pane_matcher.rb
@@ -1,8 +1,8 @@
 RSpec::Matchers.alias_matcher :be_a_pane, :a_pane
-RSpec::Matchers.define :a_pane do |expected|
+RSpec::Matchers.define :a_pane do
   attr_reader :commands
 
-  match do |pane|
+  match do
     result = is_pane
 
     result && attributes_match if @expected_attrs
@@ -15,8 +15,8 @@ RSpec::Matchers.define :a_pane do |expected|
     return "Expected #{actual} to be a Tmuxinator::Pane" unless is_pane
 
     msg = "Actual pane does not match expected"
-    msg << "\n  Expected commands #{@commands} but has #{actual.commands}" if @commands
-    msg << "\n  Expected pane to have attributes #{@expected_attrs}" if @expected_attrs
+    msg << "\n  Expected #{@commands} but has #{actual.commands}" if @commands
+    msg << "\n  Expected pane to have #{@expected_attrs}" if @expected_attrs
   end
 
   chain :with do |attrs|
@@ -29,6 +29,7 @@ RSpec::Matchers.define :a_pane do |expected|
   alias_method :and_commands, :with_commands
 
   private
+
   def attributes_match
     expect(@actual).to have_attributes(@expected_attrs)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@ require "factory_girl"
 
 FactoryGirl.find_definitions
 
+# Custom Matchers
+require_relative 'matchers/pane_matcher'
+
 RSpec.configure do |config|
   config.order = "random"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require "factory_girl"
 FactoryGirl.find_definitions
 
 # Custom Matchers
-require_relative 'matchers/pane_matcher'
+require_relative "matchers/pane_matcher"
 
 RSpec.configure do |config|
   config.order = "random"


### PR DESCRIPTION
Resolves #266 and #406 

It was easier to test my behavior using actual results not just stubbing calls to `Tmuxinator::Pane.new`.  I added a custom rspec matcher to keep the spec looking clean and spiffy.

I also removed an unused code path related to `Pane#mutliple_commands?`.  Because the pane's command arg is splatted there is always an array and it is sufficient to iterate it regardless of how many commands are contained within.