### PR TITLE
Add tmuxinator option to specify startup_pane.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New Features
 - Allow mulitple panes to be defined using yaml hash or array #266, #406
+- Add `startup_pane` #380
 
 ## 0.8.1
 ### Bugfixes
@@ -174,4 +175,3 @@
 ## 0.2.0
 - Added pane support (Thanks to Aaron Spiegel)
 - RVM support (Thanks to Jay Adkisoon)
-

--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -19,7 +19,10 @@ root: ~/
 # tmux_command: byobu
 
 # Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
-# startup_window: logs
+# startup_window: editor
+
+# Specitifes (by index) which pane of the specified window will be selected on project startup. If not set, the first pane is used.
+# startup_pane: 1
 
 # Controls whether the tmux session should be attached to automatically. Defaults to true.
 # attach: false

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -65,6 +65,7 @@ unset RBENV_DIR
   <% end %>
 
   <%= tmux %> select-window -t <%= startup_window %>
+  <%= tmux %> select-pane -t <%= startup_pane %>
 <%- end -%>
 
 <%- if attach? -%>

--- a/lib/tmuxinator/assets/wemux_template.erb
+++ b/lib/tmuxinator/assets/wemux_template.erb
@@ -47,6 +47,7 @@ if [ "$?" -eq 127 ]; then
   <%- end -%>
 
   <%= tmux %> select-window -t <%= startup_window %>
+  <%= tmux %> select-pane -t <%= startup_pane %>
 fi
 
 wemux attach

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -183,8 +183,16 @@ module Tmuxinator
       get_pane_base_index ? get_pane_base_index.to_i : get_base_index.to_i
     end
 
+    def pane_base_index
+      get_pane_base_index.to_i
+    end
+
     def startup_window
       yaml["startup_window"] || base_index
+    end
+
+    def startup_pane
+      yaml["startup_pane"] || pane_base_index
     end
 
     def tmux_options?

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -320,7 +320,7 @@ describe Tmuxinator::Project do
     end
 
     context "startup pane not specified" do
-      it "returns the first pane instead" do
+      it "returns the base pane instead" do
         allow(project).to receive_messages(pane_base_index: 4)
 
         expect(project.startup_pane).to eq(4)

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -310,6 +310,24 @@ describe Tmuxinator::Project do
     end
   end
 
+  describe "#startup_pane" do
+    context "startup pane specified" do
+      it "get the startup pane index from project config" do
+        project.yaml["startup_pane"] = 1
+
+        expect(project.startup_pane).to eq(1)
+      end
+    end
+
+    context "startup pane not specified" do
+      it "returns the first pane instead" do
+        allow(project).to receive_messages(pane_base_index: 4)
+
+        expect(project.startup_pane).to eq(4)
+      end
+    end
+  end
+
   describe "#window" do
     it "gets the window and index for tmux" do
       expect(project.window(1)).to eq "sample:1"


### PR DESCRIPTION
Fixes #380

Before this change it was only possible to select the startup_window.
This change introduces an additional option 'startup_pane'. It can be
used to select the pane of the selected window on startup. The index
uses 0...x. Consequenty only panes of the selected window
('startup_window') can be specified.