### PR TITLE
Fix for windows without panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Allow mulitple panes to be defined using yaml hash or array #266, #406
 - Add `startup_pane` #380
 
+### Bugfixes
+- Will no longer crash when no panes are specified in a window
+
 ## 0.8.1
 ### Bugfixes
 

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -27,9 +27,9 @@ module Tmuxinator
                 end
 
         @panes = build_panes(value["panes"])
-      else
-        @commands = build_commands(tmux_window_command_prefix, value)
       end
+
+      @commands = build_commands(tmux_window_command_prefix, value)
     end
 
     def build_panes(panes_yml)

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -188,6 +188,16 @@ describe Tmuxinator::Window do
         expect(window.commands).to be_empty
       end
     end
+
+    context "command is a hash" do
+      before do
+        yaml["editor"] = { "layout" => "main-horizontal", "panes" => [nil] }
+      end
+
+      it "returns an empty array" do
+        expect(window.commands).to be_empty
+      end
+    end
   end
 
   describe "#name_options" do


### PR DESCRIPTION
Fixes #328

The simple idea is that the `commands` instance variable of the `Window` class would not be initialized under certain conditions. This change ensures that `commands` will always be initialized, defaulting to an empty array.

Kudos to @fikovnik for the fix.