### PR TITLE
#432 - locking activesupport at < 5.0.0 to prevent broken builds on Ruby < 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugfixes
 - Will no longer crash when no panes are specified in a window
+- Locking activesupport at < 5.0.0 to prevent broken builds on Ruby < 2.2.3
 
 ## 0.8.1
 ### Bugfixes

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem "awesome_print", "~> 1.2"
 gem "pry", "~> 0.10"
 gem "factory_girl", "~> 4.5"
 gem "rubocop", "0.35.1", require: false
+gem "activesupport", "< 5.0.0" # Please see issue #432


### PR DESCRIPTION
Fixes #432.