### PR TITLE
Commenting out Shorthand section of README until mux symlink issue has been addressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Temporarily hiding Shorthand entry in README.md to prevent new bug reports
+  about the mux symlink being broken
 
 ### Misc
 - Refactor Config.root

--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ without tmux session name collision.
 
 If there is a `./.tmuxinator.yml` file in the current working directory but not a named project file in `~/.tmuxinator`, tmuxinator will use the local file.  This is primarily intended to be used for sharing tmux configurations in complex development environments.
 
+<!--
+
+Hiding the Shorthand entry until the mux symlink issue has been addressed.
+Please see: https://github.com/tmuxinator/tmuxinator/issues/401
+
 ## Shorthand
 
 A shorthand alias for tmuxinator can also be used.
@@ -276,6 +281,8 @@ A shorthand alias for tmuxinator can also be used.
 ```
 mux [command]
 ```
+
+-->
 
 ## Other Commands
 


### PR DESCRIPTION
This should help prevent any new "mux doesn't work" bug reports.