### PR TITLE
Replace instances of File.exists? (deprecated) with File.exist?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Misc
+- replace instances of `File.exists?` (deprecated) with `File.exist?`
 - Refactor Config.root
 
 ### New Features

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -80,7 +80,7 @@ module Tmuxinator
                else
                  Tmuxinator::Config.default_project(name)
                end
-        if File.exists?(path)
+        if File.exist?(path)
           path
         else
           generate_project_file(name, path)

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -43,7 +43,7 @@ module Tmuxinator
       end
 
       def exists?(name)
-        File.exists?(project(name))
+        File.exist?(project(name))
       end
 
       def project_in_root(name)
@@ -56,7 +56,7 @@ module Tmuxinator
       end
 
       def project_in_local
-        [LOCAL_DEFAULT].detect { |f| File.exists?(f) }
+        [LOCAL_DEFAULT].detect { |f| File.exist?(f) }
       end
 
       def default_project(name)

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -182,7 +182,7 @@ describe Tmuxinator::Cli do
 
       before do
         # make sure that no project file exists initially
-        FileUtils.remove_file(path) if File.exists?(path)
+        FileUtils.remove_file(path) if File.exist?(path)
         expect(File).not_to exist(path)
 
         # now generate a project file
@@ -222,7 +222,7 @@ describe Tmuxinator::Cli do
 
       context "existing project doesn't exist" do
         before do
-          expect(File).to receive_messages(exists?: false)
+          expect(File).to receive_messages(exist?: false)
         end
 
         it "creates a new tmuxinator project file" do
@@ -235,8 +235,8 @@ describe Tmuxinator::Cli do
         let(:root_path) { "#{ENV['HOME']}\/\.tmuxinator\/#{name}\.yml" }
 
         before do
-          allow(File).to receive(:exists?).with(anything).and_return(false)
-          expect(File).to receive(:exists?).with(root_path).and_return(true)
+          allow(File).to receive(:exist?).with(anything).and_return(false)
+          expect(File).to receive(:exist?).with(root_path).and_return(true)
         end
 
         it "just opens the file" do
@@ -253,7 +253,7 @@ describe Tmuxinator::Cli do
 
       context "existing project doesn't exist" do
         before do
-          allow(File).to receive(:exists?).at_least(:once) do
+          allow(File).to receive(:exist?).at_least(:once) do
             false
           end
         end
@@ -267,7 +267,7 @@ describe Tmuxinator::Cli do
       context "files exists" do
         let(:path) { Tmuxinator::Config::LOCAL_DEFAULT }
         before do
-          expect(File).to receive(:exists?).with(path) { true }
+          expect(File).to receive(:exist?).with(path) { true }
         end
 
         it "just opens the file" do
@@ -490,7 +490,7 @@ describe Tmuxinator::Cli do
     let(:path) { Tmuxinator::Config.default_project(name) }
 
     after(:each) do
-      FileUtils.remove_file(path) if File.exists?(path)
+      FileUtils.remove_file(path) if File.exist?(path)
     end
 
     context "when the project file does not already exist" do
@@ -538,7 +538,7 @@ describe Tmuxinator::Cli do
     end
 
     after(:each) do
-      FileUtils.remove_file(path) if File.exists?(path)
+      FileUtils.remove_file(path) if File.exist?(path)
     end
 
     it "should always generate a project file" do

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -48,8 +48,8 @@ describe Tmuxinator::Config do
 
     context "when the file exists" do
       before do
-        allow(File).to receive(:exists?).with(local_default) { false }
-        allow(File).to receive(:exists?).with(proj_default) { true }
+        allow(File).to receive(:exist?).with(local_default) { false }
+        allow(File).to receive(:exist?).with(proj_default) { true }
       end
 
       it "returns true" do
@@ -59,8 +59,8 @@ describe Tmuxinator::Config do
 
     context "when the file doesn't exist" do
       before do
-        allow(File).to receive(:exists?).with(local_default) { false }
-        allow(File).to receive(:exists?).with(proj_default) { false }
+        allow(File).to receive(:exist?).with(local_default) { false }
+        allow(File).to receive(:exist?).with(proj_default) { false }
       end
 
       it "returns true" do
@@ -147,7 +147,7 @@ describe Tmuxinator::Config do
 
   describe "#exists?" do
     before do
-      allow(File).to receive_messages(exists?: true)
+      allow(File).to receive_messages(exist?: true)
       allow(Tmuxinator::Config).to receive_messages(project: "")
     end
 
@@ -181,7 +181,7 @@ describe Tmuxinator::Config do
   describe "#local?" do
     it "checks if the given project exists" do
       path = Tmuxinator::Config::LOCAL_DEFAULT
-      expect(File).to receive(:exists?).with(path) { true }
+      expect(File).to receive(:exist?).with(path) { true }
       expect(Tmuxinator::Config.local?).to be_truthy
     end
   end
@@ -191,7 +191,7 @@ describe Tmuxinator::Config do
 
     context "with a project yml" do
       it "gets the project as path to the yml file" do
-        expect(File).to receive(:exists?).with(default) { true }
+        expect(File).to receive(:exist?).with(default) { true }
         expect(Tmuxinator::Config.project_in_local).to eq default
       end
     end
@@ -220,7 +220,7 @@ describe Tmuxinator::Config do
 
     context "with a local project, but no project in root" do
       it "gets the project as path to the yml file" do
-        expect(File).to receive(:exists?).with(default) { true }
+        expect(File).to receive(:exist?).with(default) { true }
         expect(Tmuxinator::Config.project("sample")).to eq "./.tmuxinator.yml"
       end
     end
@@ -253,7 +253,7 @@ describe Tmuxinator::Config do
 
     context "when no project name is provided" do
       it "should raise if the local project file doesn't exist" do
-        expect(File).to receive(:exists?).with(default) { false }
+        expect(File).to receive(:exist?).with(default) { false }
         expect do
           Tmuxinator::Config.validate
         end.to raise_error RuntimeError, %r{Project.+doesn't.exist}
@@ -262,7 +262,7 @@ describe Tmuxinator::Config do
       it "should load and validate the project" do
         content = File.read(File.join(path, "sample.yml"))
 
-        expect(File).to receive(:exists?).with(default).at_least(:once) { true }
+        expect(File).to receive(:exist?).with(default).at_least(:once) { true }
         expect(File).to receive(:read).with(default).and_return(content)
 
         expect(Tmuxinator::Config.validate).to be_a Tmuxinator::Project


### PR DESCRIPTION
`File.exists?` was deprecated a while back and `File.exist?` is backwards compatible to 1.9.3.

See: https://github.com/ruby/ruby/blob/trunk/file.c#L1517-L1520