### PR TITLE
Only enable Synchronize panes after the commands have run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Allow mulitple panes to be defined using yaml hash or array #266, #406
 - Add `startup_pane` #380
 - Add synchronizations panes support #97
-- Add `before` and `after` options to synchronisation functionality
+- Add `before` and `after` options to synchronization functionality
+- Add deprecation warning if `synchronize: true` or `before` is used
 
 ### Bugfixes
 - Supress `tmux ls` non-zero exit status/message when no sessions exist (#414)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Will no longer crash when no panes are specified in a window
 - Locking activesupport at < 5.0.0 to prevent broken builds on Ruby < 2.2.3
 - Fixed whitespace issues in help
+- Initial commands no longer sent to multiple panes when synchronize panes enabled
 
 ## 0.8.1
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@
 - Allow mulitple panes to be defined using yaml hash or array #266, #406
 - Add `startup_pane` #380
 - Add synchronizations panes support #97
+- Add `before` and `after` options to synchronisation functionality
 
 ### Bugfixes
 - Supress `tmux ls` non-zero exit status/message when no sessions exist (#414)
 - Will no longer crash when no panes are specified in a window
 - Locking activesupport at < 5.0.0 to prevent broken builds on Ruby < 2.2.3
 - Fixed whitespace issues in help
-- Initial commands no longer sent to multiple panes when synchronize panes enabled
 
 ## 0.8.1
 ### Bugfixes

--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -33,8 +33,9 @@ root: ~/
 windows:
   - editor:
       layout: main-vertical
-      # Synchronize all panes of this window
-      # synchronize: true
+      # Synchronize all panes of this window, can be enabled before or after the pane commands run.
+      # 'before' represents legacy functionality and will be deprecated in a future release, in favour of 'after'
+      # synchronize: after
       panes:
         - vim
         - guard

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -34,9 +34,6 @@ unset RBENV_DIR
   <% windows.each do |window| %>
 
   # Window "<%= window.name %>"
-    <% if window.synchronize %>
-  <%= window.tmux_synchronize_panes %>
-    <% end %>
     <% unless window.panes? %>
       <% if window.project.pre_window %>
   <%= window.tmux_pre_window_command %>
@@ -64,6 +61,10 @@ unset RBENV_DIR
 
   <%= window.tmux_layout_command %>
   <%= window.tmux_select_first_pane %>
+    <% end %>
+
+    <% if window.synchronize %>
+  <%= window.tmux_synchronize_panes %>
     <% end %>
   <% end %>
 

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -34,6 +34,9 @@ unset RBENV_DIR
   <% windows.each do |window| %>
 
   # Window "<%= window.name %>"
+    <% if window.synchronize_before? %>
+  <%= window.tmux_synchronize_panes %>
+    <% end %>
     <% unless window.panes? %>
       <% if window.project.pre_window %>
   <%= window.tmux_pre_window_command %>
@@ -63,7 +66,7 @@ unset RBENV_DIR
   <%= window.tmux_select_first_pane %>
     <% end %>
 
-    <% if window.synchronize %>
+    <% if window.synchronize_after? %>
   <%= window.tmux_synchronize_panes %>
     <% end %>
   <% end %>

--- a/lib/tmuxinator/assets/wemux_template.erb
+++ b/lib/tmuxinator/assets/wemux_template.erb
@@ -23,6 +23,9 @@ if [ "$?" -eq 127 ]; then
   <%- windows.each do |window| -%>
 
   # Window "<%= window.name %>"
+    <% if window.synchronize_before? %>
+  <%= window.tmux_synchronize_panes %>
+    <% end %>
     <%- unless window.panes? -%>
   <%= window.tmux_pre_window_command %>
     <%- window.commands.each do |command| -%>
@@ -45,7 +48,7 @@ if [ "$?" -eq 127 ]; then
   <%= window.tmux_select_first_pane %>
     <%- end -%>
 
-    <%- if window.synchronize -%>
+    <%- if window.synchronize_after? -%>
   <%= window.tmux_synchronize_panes %>
     <%- end %>
   <%- end -%>

--- a/lib/tmuxinator/assets/wemux_template.erb
+++ b/lib/tmuxinator/assets/wemux_template.erb
@@ -23,9 +23,6 @@ if [ "$?" -eq 127 ]; then
   <%- windows.each do |window| -%>
 
   # Window "<%= window.name %>"
-    <%- if window.synchronize -%>
-  <%= window.tmux_synchronize_panes %>
-    <%- end %>
     <%- unless window.panes? -%>
   <%= window.tmux_pre_window_command %>
     <%- window.commands.each do |command| -%>
@@ -47,6 +44,10 @@ if [ "$?" -eq 127 ]; then
 
   <%= window.tmux_select_first_pane %>
     <%- end -%>
+
+    <%- if window.synchronize -%>
+  <%= window.tmux_synchronize_panes %>
+    <%- end %>
   <%- end -%>
 
   <%= tmux %> select-window -t <%= startup_window %>

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -16,6 +16,12 @@ module Tmuxinator
     DEPRECATION: The cli_args option has been replaced by the tmux_options
     option and will not be supported in 0.8.0.
     M
+    SYNC_DEP_MSG = <<-M
+    DEPRECATION: The synchronize option's current default behaviour is to
+    enable pane synchronization before running commands. As of 0.8.2, by
+    default, synchronization will only be enabled after the commands have
+    ran. To use this behaviour now use the 'synchronize: after' option.
+    M
 
     attr_reader :yaml
     attr_reader :force_attach
@@ -239,6 +245,7 @@ module Tmuxinator
       deprecations << RBENVRVM_DEP_MSG if yaml["rbenv"] || yaml["rvm"]
       deprecations << TABS_DEP_MSG if yaml["tabs"]
       deprecations << CLIARGS_DEP_MSG if yaml["cli_args"]
+      deprecations << SYNC_DEP_MSG if legacy_synchronize?
       deprecations
     end
 
@@ -281,6 +288,20 @@ module Tmuxinator
       end
 
       options_hash
+    end
+
+    def legacy_synchronize?
+      (synchronize_options & [true, "before"]).any?
+    end
+
+    def synchronize_options
+      window_options.map do |option|
+        option["synchronize"] if option.is_a?(Hash)
+      end
+    end
+
+    def window_options
+      yaml["windows"].map(&:values).flatten
     end
   end
 end

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -115,5 +115,13 @@ module Tmuxinator
     def tmux_select_first_pane
       "#{project.tmux} select-pane -t #{tmux_window_target}.#{panes.first.index + project.base_index}"
     end
+
+    def synchronize_before?
+      synchronize == true || synchronize == "before"
+    end
+
+    def synchronize_after?
+      synchronize == "after"
+    end
   end
 end

--- a/spec/fixtures/sample.deprecations.yml
+++ b/spec/fixtures/sample.deprecations.yml
@@ -32,3 +32,6 @@ tabs:
   - console: bundle exec rails c
   - capistrano:
   - server: ssh user@example.com
+windows:
+  - sample:
+    - synchronize: true

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -239,27 +239,67 @@ describe Tmuxinator::Window do
     end
   end
 
-  describe "#synchronize" do
-    context "synchronization enabled" do
+  describe "#synchronize_before?" do
+    subject { window.synchronize_before? }
+
+    context "synchronize is 'before'" do
+      let(:synchronize) { "before" }
+
+      it { is_expected.to be true }
+    end
+
+    context "synchronize is true" do
       let(:synchronize) { true }
 
-      it "should have synchronization enabled" do
-        expect(window.synchronize).to be true
-      end
+      it { is_expected.to be true }
+    end
+
+    context "synchronize is 'after'" do
+      let(:synchronize) { "after" }
+
+      it { is_expected.to be false }
     end
 
     context "synchronization disabled" do
       let(:synchronize) { false }
 
-      it "should have synchronization disabled" do
-        expect(window.synchronize).to be false
-      end
+      it { is_expected.to be false }
     end
 
     context "synchronization not specified" do
-      it "should have synchronization disabled" do
-        expect(window.synchronize).to be false
-      end
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#synchronize_after?" do
+    subject { window.synchronize_after? }
+
+    context "synchronization is 'after'" do
+      let(:synchronize) { "after" }
+
+      it { is_expected.to be true }
+    end
+
+    context "synchronization is true" do
+      let(:synchronize) { true }
+
+      it { is_expected.to be false }
+    end
+
+    context "synchronization is 'before'" do
+      let(:synchronize) { "before" }
+
+      it { is_expected.to be false }
+    end
+
+    context "synchronization disabled" do
+      let(:synchronize) { false }
+
+      it { is_expected.to be false }
+    end
+
+    context "synchronization not specified" do
+      it { is_expected.to be false }
     end
   end
 


### PR DESCRIPTION
Further to PR https://github.com/tmuxinator/tmuxinator/pull/423, if synchronization is enabled. As each pane is created, existing panes also receive each command string.

For example
```
windows:
  - editor:
      layout: main-vertical
      synchronize: true
      panes:
        - echo 'pane 1'
        - echo 'pane 2'
        - echo 'pane 3'
        - echo 'pane 4'
```
Results in
![image](https://cloud.githubusercontent.com/assets/1025225/17365032/b6f7dce4-597b-11e6-93b1-ebc9ffcef2d5.png)

I'm not sure if this is desired behaviour. However in my use case (ssh'ing to multiple servers) I found it could potentially cause issues.

Addressed by moving the call to sync panes to after the pane creation.