### PR TITLE
385 introduce tmux validator [WIP]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Add synchronizations panes support #97
 - Add `before` and `after` options to synchronization functionality
 - Add deprecation warning if `synchronize: true` or `before` is used
+- Add TmuxValidator, which currently only validates that tmux has been installed
+  and is available on $PATH. In the future, this module could also be used to
+  validate minimum tmux version, etc. #385
 
 ### Bugfixes
 - Supress `tmux ls` non-zero exit status/message when no sessions exist (#414)

--- a/lib/tmuxinator.rb
+++ b/lib/tmuxinator.rb
@@ -15,7 +15,8 @@ require "tmuxinator/window"
 require "tmuxinator/version"
 require "tmuxinator/tmux_validator"
 
-module Tmuxinator; end
+module Tmuxinator
+end
 
 class Object
   def blank?

--- a/lib/tmuxinator.rb
+++ b/lib/tmuxinator.rb
@@ -13,9 +13,9 @@ require "tmuxinator/pane"
 require "tmuxinator/project"
 require "tmuxinator/window"
 require "tmuxinator/version"
+require "tmuxinator/tmux_validator"
 
-module Tmuxinator
-end
+module Tmuxinator; end
 
 class Object
   def blank?

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -140,6 +140,7 @@ module Tmuxinator
                          desc: "Give the session a different name"
 
     def start(name, *args)
+      Tmuxinator::TmuxValidator::validate!
       params = {
         name: name,
         custom_name: options[:name],

--- a/lib/tmuxinator/tmux_validator.rb
+++ b/lib/tmuxinator/tmux_validator.rb
@@ -1,0 +1,15 @@
+module Tmuxinator
+  module TmuxValidator
+    TMUX_IS_NOT_AVAILABLE_MESSAGE = <<-TMUX_IS_NOT_AVAILABLE
+Please ensure tmux has been installed and is available on $PATH.
+TMUX_IS_NOT_AVAILABLE
+
+    def self.validate!
+      raise TMUX_IS_NOT_AVAILABLE_MESSAGE if tmux_is_not_available
+    end
+
+    def self.tmux_is_not_available
+      !Tmuxinator::Config::installed?
+    end
+  end
+end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -59,6 +59,7 @@ describe Tmuxinator::Cli do
   describe "#start" do
     before do
       ARGV.replace(["start", "foo"])
+      allow(Tmuxinator::Config).to receive(:installed?).and_return true
       allow(Tmuxinator::Config).to receive_messages(validate: project)
       allow(Tmuxinator::Config).to receive_messages(version: 1.9)
       allow(Kernel).to receive(:exec)
@@ -104,6 +105,7 @@ describe Tmuxinator::Cli do
   describe "#stop" do
     before do
       ARGV.replace(["stop", "foo"])
+      allow(Tmuxinator::Config).to receive(:installed?).and_return true
       allow(Tmuxinator::Config).to receive_messages(validate: project)
       allow(Tmuxinator::Config).to receive_messages(version: 1.9)
       allow(Kernel).to receive(:exec)
@@ -157,6 +159,7 @@ describe Tmuxinator::Cli do
   describe "#start(custom_name)" do
     before do
       ARGV.replace(["start", "foo", "bar"])
+      allow(Tmuxinator::Config).to receive(:installed?).and_return true
       allow(Tmuxinator::Config).to receive_messages(validate: project)
       allow(Tmuxinator::Config).to receive_messages(version: 1.9)
       allow(Kernel).to receive(:exec)

--- a/spec/lib/tmuxinator/tmux_validator_spec.rb
+++ b/spec/lib/tmuxinator/tmux_validator_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+describe Tmuxinator do
+  context "tmux has not been installed or is not available" do
+    it "raises a useful exception" do
+      allow(Tmuxinator::TmuxValidator).
+        to receive(:tmux_is_not_available).
+        and_return true
+      expect { Tmuxinator::TmuxValidator::validate! }.
+        to raise_error RuntimeError,
+                       Tmuxinator::TmuxValidator::TMUX_IS_NOT_AVAILABLE_MESSAGE
+    end
+  end
+end


### PR DESCRIPTION
Addresses #385.

A few items of note:
- "validation" currently takes place in `Cli#start`, but that's definitely up for debate. Personally, I'd run the "validation" inside the Tmuxinator module definition. However, it's feasible that someone would want to use Tmuxinator to delete existing projects, run `tmuxinator implode`, etc. after having uninstalled tmux.
- TmuxValidator currently raises a `RuntimeError` when tmux is unavailable. I'd prefer to raise a custom error like, `TmuxIsNotAvailable`, but I don't believe that's being done anywhere else in the project, so I don't want to break formation. It might also make sense to use `Util#exit!` to avoid dumping a stack trace on unassuming users.
