### PR TITLE
introduce and use noroot fixture/factory in project_spec

### DIFF
--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -73,6 +73,14 @@ FactoryGirl.define do
     initialize_with { Tmuxinator::Project.new(file) }
   end
 
+  factory :noroot_project, class: Tmuxinator::Project do
+    transient do
+      file { yaml_load("spec/fixtures/noroot.yml") }
+    end
+
+    initialize_with { Tmuxinator::Project.new(file) }
+  end
+
   factory :nowindows_project, class: Tmuxinator::Project do
     transient do
       file { yaml_load("spec/fixtures/nowindows.yml") }

--- a/spec/fixtures/noroot.yml
+++ b/spec/fixtures/noroot.yml
@@ -1,0 +1,5 @@
+# ~/.tmuxinator/noroot.yml
+# you can make as many tabs as you wish...
+
+windows:
+  - test: echo foo

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -23,6 +23,7 @@ describe Tmuxinator::Project do
 
   let(:wemux_project) { FactoryGirl.build(:wemux_project) }
   let(:noname_project) { FactoryGirl.build(:noname_project) }
+  let(:noroot_project) { FactoryGirl.build(:noroot_project) }
   let(:nameless_window_project) do
     FactoryGirl.build(:nameless_window_project)
   end
@@ -123,7 +124,7 @@ describe Tmuxinator::Project do
 
     context "without root" do
       it "doesn't throw an error" do
-        expect { noname_project.root }.to_not raise_error
+        expect { noroot_project.root }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
I noticed this omission while looking into #458.

- introduces noroot fixture
- introduces factory for noroot fixture
- uses noroot factory (instead of noname factory) in "without root" test