### PR TITLE
Add ability for pre_window commands to parse yaml arrays (as well as strings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+
+- Add ability for pre_window commands to parse yaml arrays
+
 ### Misc
 - Removed support for Ruby 1.9.3
 - Move gem dependencies from Gemfile to tmuxinator.gemspec

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -135,7 +135,8 @@ module Tmuxinator
       elsif pre_tab?
         yaml["pre_tab"]
       else
-        yaml["pre_window"]
+        pre_window = yaml["pre_window"]
+        pre_window.is_a?(Array) ? pre_window.join("; ") : pre_window
       end
     end
 

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -110,11 +110,7 @@ module Tmuxinator
 
     def pre
       pre_config = yaml["pre"]
-      if pre_config.is_a?(Array)
-        pre_config.join("; ")
-      else
-        pre_config
-      end
+      parsed_parameters(pre_config)
     end
 
     def attach?
@@ -136,17 +132,13 @@ module Tmuxinator
         yaml["pre_tab"]
       else
         pre_window = yaml["pre_window"]
-        pre_window.is_a?(Array) ? pre_window.join("; ") : pre_window
+        parsed_parameters(pre_window)
       end
     end
 
     def post
       post_config = yaml["post"]
-      if post_config.is_a?(Array)
-        post_config.join("; ")
-      else
-        post_config
-      end
+      parsed_parameters(post_config)
     end
 
     def tmux
@@ -306,6 +298,10 @@ module Tmuxinator
 
     def window_options
       yaml["windows"].map(&:values).flatten
+    end
+
+    def parsed_parameters(parameters)
+      parameters.is_a?(Array) ? parameters.join("; ") : parameters
     end
   end
 end

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -123,17 +123,17 @@ module Tmuxinator
       attach
     end
 
-    def pre_window
+    def pre_window      
       if rbenv?
-        "rbenv shell #{yaml['rbenv']}"
+        params = "rbenv shell #{yaml['rbenv']}"
       elsif rvm?
-        "rvm use #{yaml['rvm']}"
+        params = "rvm use #{yaml['rvm']}"
       elsif pre_tab?
-        yaml["pre_tab"]
+        params = yaml["pre_tab"]
       else
-        pre_window = yaml["pre_window"]
-        parsed_parameters(pre_window)
+        params = yaml["pre_window"]        
       end
+      parsed_parameters(params)
     end
 
     def post

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -123,7 +123,7 @@ module Tmuxinator
       attach
     end
 
-    def pre_window      
+    def pre_window
       if rbenv?
         params = "rbenv shell #{yaml['rbenv']}"
       elsif rvm?
@@ -131,7 +131,7 @@ module Tmuxinator
       elsif pre_tab?
         params = yaml["pre_tab"]
       else
-        params = yaml["pre_window"]        
+        params = yaml["pre_window"]
       end
       parsed_parameters(params)
     end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -172,8 +172,27 @@ describe Tmuxinator::Project do
   end
 
   describe "#pre_window" do
-    it "gets the pre_window command" do
-      expect(project.pre_window).to eq "rbenv shell 2.0.0-p247"
+    subject(:pre_window) { project.pre_window }
+
+    context "pre_window in yaml is string" do
+      before { project.yaml["pre_window"] = "mysql.server start" }
+
+      it "returns the string" do
+        expect(pre_window).to eq("mysql.server start")
+      end
+    end
+
+    context "pre_window in yaml is Array" do
+      before do
+        project.yaml["pre_window"] = [
+          "mysql.server start",
+          "memcached -d"
+        ]
+      end
+
+      it "joins array using ;" do
+        expect(pre_window).to eq("mysql.server start; memcached -d")
+      end
     end
 
     context "with deprecations" do


### PR DESCRIPTION
Currently, only `pre` commands accept yaml strings and arrays. This commit adds the ability for `pre_window` commands to also accept yaml strings and arrays.