### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Removed support for Ruby 1.9.3
 - Move gem dependencies from Gemfile to tmuxinator.gemspec
 - Add tmux 2.2 and 2.3 the TravisCI test matrix
+- Fix typos
 
 ## 0.9.0
 ### Misc
@@ -13,14 +14,14 @@
 - Refactor Config.root
 
 ### New Features
-- Allow mulitple panes to be defined using yaml hash or array #266, #406
+- Allow multiple panes to be defined using yaml hash or array #266, #406
 - Add `startup_pane` #380
 - Add synchronizations panes support #97
 - Add `before` and `after` options to synchronization functionality
 - Add deprecation warning if `synchronize: true` or `before` is used
 
 ### Bugfixes
-- Supress `tmux ls` non-zero exit status/message when no sessions exist (#414)
+- Suppress `tmux ls` non-zero exit status/message when no sessions exist (#414)
 - Will no longer crash when no panes are specified in a window
 - Locking activesupport at < 5.0.0 to prevent broken builds on Ruby < 2.2.3
 - Fixed whitespace issues in help
@@ -59,7 +60,7 @@
 
 ### Bug fixes and Misc
 - Fix some RSpec deprecations
-- Explain what EBR is in the readme #319
+- Explain what ERB is in the readme #319
 - Prevent project names containing only numbers from raising a NoMethodError #324
 - Fix YAML syntax highlighting in readme #325
 - Add `asset_path` helper #326
@@ -117,8 +118,8 @@
 - Improve error messages when $EDITOR isn't set #186, #194
 - Add confirmation to deletion prompt #197
 - Fix broken badge references after organisation move
-- Remove dependancy on ActiveSupport #199
-- Fix compatability with tmux 1.9
+- Remove dependency on ActiveSupport #199
+- Fix compatibility with tmux 1.9
 
 ## 0.6.6
 - Fix a bug caused by not escaping the root path #145

--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -21,7 +21,7 @@ root: ~/
 # Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
 # startup_window: editor
 
-# Specitifes (by index) which pane of the specified window will be selected on project startup. If not set, the first pane is used.
+# Specifies (by index) which pane of the specified window will be selected on project startup. If not set, the first pane is used.
 # startup_pane: 1
 
 # Controls whether the tmux session should be attached to automatically. Defaults to true.

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -19,7 +19,7 @@ module Tmuxinator
     SYNC_DEP_MSG = <<-M
     DEPRECATION: The synchronize option's current default behaviour is to
     enable pane synchronization before running commands. In a future release,
-    the default syncronization option will be `after`, i.e. synchronization of
+    the default synchronization option will be `after`, i.e. synchronization of
     panes will occur after the commands described in each of the panes
     have run. At that time, the current behavior will need to be explicitly
     enabled, using the `synchronize: before` option.  To use this behaviour

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -295,7 +295,7 @@ describe Tmuxinator::Cli do
       end
     end
 
-    context "existing project doens't exist" do
+    context "existing project doesn't exist" do
       before do
         allow(Tmuxinator::Config).to receive(:exists?) { false }
       end

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Tmuxinator::Config do
   describe "#root" do
-    it "is ~/.tmuxintaor" do
+    it "is ~/.tmuxinator" do
       expect(Tmuxinator::Config.root).to eq "#{ENV['HOME']}/.tmuxinator"
     end
   end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -502,7 +502,7 @@ describe Tmuxinator::Project do
     let(:window) { project.windows.first.name }
 
     context "when first window has a name" do
-      it "returns command to start a new detatched session" do
+      it "returns command to start a new detached session" do
         expect(project.tmux_new_session_command).to eq command
       end
     end
@@ -511,7 +511,7 @@ describe Tmuxinator::Project do
       let(:project) { nameless_window_project }
       let(:command) { "#{project.tmux} new-session -d -s #{project.name} " }
 
-      it "returns command to for new detatched session without a window name" do
+      it "returns command to for new detached session without a window name" do
         expect(project.tmux_new_session_command).to eq command
       end
     end
@@ -523,7 +523,7 @@ describe Tmuxinator::Project do
     let(:session) { project.name }
 
     context "when first window has a name" do
-      it "returns command to start a new detatched session" do
+      it "returns command to start a new detached session" do
         expect(project.tmux_kill_session_command).to eq command
       end
     end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -341,7 +341,7 @@ describe Tmuxinator::Window do
       allow(Tmuxinator::Config).to receive(:default_path_option) { path_option }
     end
 
-    it "contstructs window command with path, target, and name options" do
+    it "constructs window command with path, target, and name options" do
       expect(window.tmux_new_window_command).to eq full_command
     end
 


### PR DESCRIPTION
Noticed a typo in `sample.yml` when I was installing. Went through the code with `aspell` to clean things up.