### PR TITLE
Directory support

### DIFF
--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -91,6 +91,10 @@ module Tmuxinator
         template = Tmuxinator::Config.default? ? :default : :sample
         content = File.read(Tmuxinator::Config.send(template.to_sym))
         erb = Erubis::Eruby.new(content).result(binding)
+        dirname = File.dirname(path)
+        unless File.directory?(dirname)
+          FileUtils.mkdir_p(dirname)
+        end
         File.open(path, "w") { |f| f.write(erb) }
         path
       end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -546,6 +546,17 @@ describe Tmuxinator::Cli do
       expect(new_path).to eq path
       expect(File).to exist new_path
     end
+
+    context "when path is nested" do
+      let(:name) { "foobar/baz" }
+      let(:path) { Tmuxinator::Config.default_project(name) }
+
+      it "should always generate a project file" do
+        new_path = Tmuxinator::Cli.new.generate_project_file(name, path)
+        expect(new_path).to eq path
+        expect(File).to exist new_path
+      end
+    end
   end
 
   describe "#create_project" do


### PR DESCRIPTION
## Why
I wanna create a project like `foo/project1`, `foo/project2`. But, it raises `No such file or directory` because it just`File.open(path)`.

## What
When names are nested, it creates a directory.