### PR TITLE
updates rubocop to 0.46.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,9 +10,10 @@ AllCops:
   Exclude:
   - "vendor/**/*"
   - "db/schema.rb"
-  RunRailsCops: false
-  DisplayCopNames: false
+  DisplayCopNames: true
   StyleGuideCopsOnly: false
+Rails:
+  Enabled: false
 Style/AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
@@ -425,14 +426,10 @@ Style/TrailingBlankLines:
   SupportedStyles:
   - final_newline
   - final_blank_line
-Style/TrailingComma:
-  Description: Checks for trailing comma in parameter lists and literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+Style/TrailingCommaInLiteral:
   Enabled: false
-  EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
-  - comma
-  - no_comma
+Style/TrailingCommaInArguments:
+  Enabled: true
 Style/TrivialAccessors:
   Description: Prefer attr_* methods to trivial readers/writers.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr_family
@@ -526,6 +523,18 @@ Metrics/PerceivedComplexity:
     reader.
   Enabled: false
   Max: 7
+Metrics/BlockLength:
+  Exclude:
+    - lib/tmuxinator/cli.rb
+    - spec/factories/**/*.rb
+    - spec/matchers/**/*.rb
+    - spec/**/*_spec.rb
+Lint/PercentStringArray:
+  Exclude:
+    - lib/tmuxinator/cli.rb
+Style/MutableConstant:
+  Exclude:
+    - lib/tmuxinator/project.rb
 Lint/AssignmentInCondition:
   Description: Don't use assignment in conditions.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
@@ -545,48 +554,6 @@ Lint/DefEndAlignment:
   SupportedStyles:
   - start_of_line
   - def
-Rails/ActionFilter:
-  Description: Enforces consistent use of action filter methods.
-  Enabled: false
-  EnforcedStyle: action
-  SupportedStyles:
-  - action
-  - filter
-  Include:
-  - app/controllers/**/*.rb
-Rails/DefaultScope:
-  Description: Checks if the argument passed to default_scope is a block.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/HasAndBelongsToMany:
-  Description: Prefer has_many :through to has_and_belongs_to_many.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/Output:
-  Description: Checks for calls to puts, print, etc.
-  Enabled: true
-  Include:
-  - app/**/*.rb
-  - config/**/*.rb
-  - db/**/*.rb
-  - lib/**/*.rb
-Rails/ReadWriteAttribute:
-  Description: Checks for read_attribute(:attr) and write_attribute(:attr, val).
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/ScopeArgs:
-  Description: Checks the arguments of ActiveRecord scopes.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/Validation:
-  Description: Use validates :attribute, hash of validations.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
 Style/InlineComment:
   Description: Avoid inline comments.
   Enabled: false
@@ -679,10 +646,6 @@ Style/DefWithParentheses:
   Description: Use def with parentheses when there are arguments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#method-parens
   Enabled: true
-Style/DeprecatedHashMethods:
-  Description: Checks for use of deprecated Hash methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
-  Enabled: false
 Style/Documentation:
   Description: Document classes and non-namespace modules.
   Enabled: false
@@ -834,7 +797,7 @@ Style/SelfAssignment:
     used.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
   Enabled: false
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Description: Checks that exactly one space is used between a method name and the
     first argument for method calls without parentheses.
   Enabled: true
@@ -846,8 +809,7 @@ Style/SpaceAfterComma:
   Description: Use spaces after commas.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
-Style/SpaceAfterControlKeyword:
-  Description: Use spaces after if/elsif/unless/while/until/case/when.
+Style/SpaceAroundKeyword:
   Enabled: true
 Style/SpaceAfterMethodName:
   Description: Do not put a space between a method name and the opening parenthesis
@@ -874,9 +836,6 @@ Style/SpaceBeforeSemicolon:
 Style/SpaceAroundOperators:
   Description: Use spaces around operators.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceBeforeModifierKeyword:
-  Description: Put a space before the modifier keyword.
   Enabled: true
 Style/SpaceInsideBrackets:
   Description: No spaces after [ or before ].
@@ -1013,10 +972,6 @@ Lint/ShadowingOuterLocalVariable:
   Description: Do not use the same name as outer local variable for block arguments
     or block local variables.
   Enabled: true
-Lint/SpaceBeforeFirstArg:
-  Description: Put a space between a method name and the first argument in a method
-    call without parentheses.
-  Enabled: true
 Lint/StringConversionInInterpolation:
   Description: Checks for Object#to_s usage in string interpolation.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-to-s
@@ -1053,7 +1008,4 @@ Lint/UselessSetterCall:
   Enabled: true
 Lint/Void:
   Description: Possible use of operator/literal/variable in void context.
-  Enabled: false
-Rails/Delegate:
-  Description: Prefer delegate method for delegations.
   Enabled: false

--- a/bin/tmuxinator
+++ b/bin/tmuxinator
@@ -6,7 +6,7 @@ require "tmuxinator"
 
 name = ARGV[0] || nil
 
-if ARGV.length == 0 && Tmuxinator::Config.local?
+if ARGV.empty? && Tmuxinator::Config.local?
   Tmuxinator::Cli.new.local
 elsif name && !Tmuxinator::Cli::COMMANDS.keys.include?(name.to_sym) &&
       Tmuxinator::Config.exists?(name)

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -30,7 +30,7 @@ module Tmuxinator
       version: "Display installed tmuxinator version",
       doctor: "Look for problems in your configuration",
       list: "Lists all tmuxinator projects"
-    }
+    }.freeze
 
     package_name "tmuxinator" \
       unless Gem::Version.create(Thor::VERSION) < Gem::Version.create("0.18")

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -1,7 +1,8 @@
 module Tmuxinator
   class Config
     LOCAL_DEFAULT = "./.tmuxinator.yml".freeze
-    NO_LOCAL_FILE_MSG = "Project file at ./.tmuxinator.yml doesn't exist."
+    NO_LOCAL_FILE_MSG =
+      "Project file at ./.tmuxinator.yml doesn't exist.".freeze
 
     class << self
       def root

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -62,9 +62,9 @@ module Tmuxinator
 
     def validate!
       raise "Your project file should include some windows." \
-        unless self.windows?
+        unless windows?
       raise "Your project file didn't specify a 'project_name'" \
-        unless self.name?
+        unless name?
       self
     end
 
@@ -114,25 +114,25 @@ module Tmuxinator
     end
 
     def attach?
-      if yaml["attach"].nil?
-        yaml_attach = true
-      else
-        yaml_attach = yaml["attach"]
-      end
+      yaml_attach = if yaml["attach"].nil?
+                      true
+                    else
+                      yaml["attach"]
+                    end
       attach = force_attach || !force_detach && yaml_attach
       attach
     end
 
     def pre_window
-      if rbenv?
-        params = "rbenv shell #{yaml['rbenv']}"
-      elsif rvm?
-        params = "rvm use #{yaml['rvm']}"
-      elsif pre_tab?
-        params = yaml["pre_tab"]
-      else
-        params = yaml["pre_window"]
-      end
+      params = if rbenv?
+                 "rbenv shell #{yaml['rbenv']}"
+               elsif rvm?
+                 "rvm use #{yaml['rvm']}"
+               elsif pre_tab?
+                 yaml["pre_tab"]
+               else
+                 yaml["pre_window"]
+               end
       parsed_parameters(params)
     end
 

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "0.9.0"
+  VERSION = "0.9.0".freeze
 end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -73,7 +73,7 @@ describe Tmuxinator::Cli do
       end
 
       it "accepts a flag for alternate name" do
-        ARGV.replace(["start", "foo" "--name=bar"])
+        ARGV.replace(["start", "foo", "--name=bar"])
 
         expect(Kernel).to receive(:exec)
         capture_io { cli.start }

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -166,7 +166,8 @@ describe Tmuxinator::Project do
         rendered = project_with_literals_as_window_name
         expect(rendered.windows.map(&:name)).to match_array(
           %w(222 222333 111222333444555666777 222.3 4e5 4E5
-             true false nil // /sample/))
+             true false nil // /sample/)
+        )
       end
     end
   end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -99,11 +99,13 @@ describe Tmuxinator::Window do
           project: project, tab: window
         )
 
-        expect(window.panes).to match([
-          a_pane.with(index: 0).and_commands("vim"),
-          a_pane.with(index: 1).and_commands("ls"),
-          a_pane.with(index: 2).and_commands("top")
-        ])
+        expect(window.panes).to match(
+          [
+            a_pane.with(index: 0).and_commands("vim"),
+            a_pane.with(index: 1).and_commands("ls"),
+            a_pane.with(index: 2).and_commands("top")
+          ]
+        )
       end
     end
 

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -50,6 +50,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry", "~> 0.10"
   s.add_development_dependency "factory_girl", "~> 4.5"
   s.add_development_dependency "activesupport", "< 5.0.0" # Please see issue #432
-  s.add_development_dependency "rubocop", "~> 0.35.1"
+  s.add_development_dependency "rubocop", "~> 0.46.0"
 end
 


### PR DESCRIPTION
used by CodeClimate

- removes old cops
- updates source to accommodate new cops