### PR TITLE
Refactor Window attr_reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Remove unused attr_readers from Tmuxinator::Window
 - Add ability for pre_window commands to parse yaml arrays
 
 ### Misc

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -2,7 +2,7 @@ module Tmuxinator
   class Window
     include Tmuxinator::Util
 
-    attr_reader :name, :root, :panes, :layout, :commands, :index, :project, :synchronize
+    attr_reader :commands, :index, :name, :project
 
     def initialize(window_yaml, index, project)
       first_key = window_yaml.keys.first


### PR DESCRIPTION
While revisiting #410, I noticed there were a number of unused `attr_readers` in `Tmuxinator::Window`. They're not causing any harm (with the exception - I imagine - of some unnecessary overhead caused by their associated getters), but I figured removing them might prevent future confusion.