### PR TITLE
fix default path for tmux master

### DIFF
--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -53,7 +53,7 @@ module Tmuxinator
       end
 
       def default_path_option
-        version && version < 1.8 ? "default-path" : "-c"
+        version && version < 1.8 && version > 0.0 ? "default-path" : "-c"
       end
 
       def editor?


### PR DESCRIPTION
I'm using tmux master branch with tmuxinator and get the error reading `invalid option default-path`. The version has `to_f` so for something like `tmux -V` that returns `tmux master`, we get 0.0 and thus the `default-path` is generated instead of `-c`. I feel this is not very pretty but I hope this is acceptable in terms of real usage.