### PR TITLE
Decouple base_index from pane_base_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Refactor Tmuxinator::Config by extracting a Tmuxinator::Doctor class (#457)
 - Fix a bug where startup_window and startup_pane were not respected if running
   tmuxinator from within an existing tmux session (#537)
+- Fix a bug causing the pane-base-index option to override base-index
 
 ### Misc
 - Removed support for Ruby 1.9.3

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -202,7 +202,7 @@ module Tmuxinator
     end
 
     def base_index
-      get_pane_base_index ? get_pane_base_index.to_i : get_base_index.to_i
+      get_base_index.to_i
     end
 
     def pane_base_index

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -310,24 +310,33 @@ describe Tmuxinator::Project do
   end
 
   describe "#base_index" do
-    context "pane base index present" do
+    context "when pane_base_index is 1 and base_index is unset" do
       before do
         allow(project).to receive_messages(get_pane_base_index: "1")
+        allow(project).to receive_messages(get_base_index: nil)
+      end
+
+      it "gets the tmux default of 0" do
+        expect(project.base_index).to eq(0)
+      end
+    end
+
+    context "base index present" do
+      before do
         allow(project).to receive_messages(get_base_index: "1")
       end
 
-      it "gets the pane base index" do
+      it "gets the base index" do
         expect(project.base_index).to eq 1
       end
     end
 
-    context "pane base index no present" do
+    context "base index not present" do
       before do
-        allow(project).to receive_messages(get_pane_base_index: nil)
-        allow(project).to receive_messages(get_base_index: "0")
+        allow(project).to receive_messages(get_base_index: nil)
       end
 
-      it "gets the base index" do
+      it "defaults to 0" do
         expect(project.base_index).to eq 0
       end
     end


### PR DESCRIPTION
The pane_base_index and base_index options are set and handled independently in tmux, so the value of pane_base_index should not override the value of base_index (as it previously was).