### PR TITLE
[Fixes #537] Use full paths for startup window/pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Remove unused attr_readers from Tmuxinator::Window
 - Add ability for pre_window commands to parse yaml arrays
 - Refactor Tmuxinator::Config by extracting a Tmuxinator::Doctor class (#457)
+- Fix a bug where startup_window and startup_pane were not respected if running
+  tmuxinator from within an existing tmux session (#537)
 
 ### Misc
 - Removed support for Ruby 1.9.3

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -210,11 +210,11 @@ module Tmuxinator
     end
 
     def startup_window
-      yaml["startup_window"] || base_index
+      "#{name}:#{yaml['startup_window'] || base_index}"
     end
 
     def startup_pane
-      yaml["startup_pane"] || pane_base_index
+      "#{startup_window}.#{yaml['startup_pane'] || pane_base_index}"
     end
 
     def tmux_options?

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -338,7 +338,7 @@ describe Tmuxinator::Project do
       it "gets the startup window from project config" do
         project.yaml["startup_window"] = "logs"
 
-        expect(project.startup_window).to eq("logs")
+        expect(project.startup_window).to eq("sample:logs")
       end
     end
 
@@ -346,7 +346,7 @@ describe Tmuxinator::Project do
       it "returns base index instead" do
         allow(project).to receive_messages(base_index: 8)
 
-        expect(project.startup_window).to eq 8
+        expect(project.startup_window).to eq("sample:8")
       end
     end
   end
@@ -356,7 +356,7 @@ describe Tmuxinator::Project do
       it "get the startup pane index from project config" do
         project.yaml["startup_pane"] = 1
 
-        expect(project.startup_pane).to eq(1)
+        expect(project.startup_pane).to eq("sample:0.1")
       end
     end
 
@@ -364,7 +364,7 @@ describe Tmuxinator::Project do
       it "returns the base pane instead" do
         allow(project).to receive_messages(pane_base_index: 4)
 
-        expect(project.startup_pane).to eq(4)
+        expect(project.startup_pane).to eq("sample:0.4")
       end
     end
   end


### PR DESCRIPTION
The startup_window and startup_pane options were not behaving correctly for users running tmuxinator from within an existing tmux session.  Tmuxinator would generate commands like `tmux select-window -t 1`, which would target the current session instead of the target (project) session. This bug is fixed by specifying full paths (`session:window.pane`) for the startup_window and startup_pane.