### PR TITLE
adds specific version for when tmux's version is 'master' (99.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Remove unused attr_readers from Tmuxinator::Window
 - Add ability for pre_window commands to parse yaml arrays
 - Refactor Tmuxinator::Config by extracting a Tmuxinator::Doctor class (#457)
+- Refactors Tmuxinator::Confir.version to display a high value number for `tmux`'s `master` branch
 
 ### Misc
 - Removed support for Ruby 1.9.3

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -3,6 +3,7 @@ module Tmuxinator
     LOCAL_DEFAULT = "./.tmuxinator.yml".freeze
     NO_LOCAL_FILE_MSG =
       "Project file at ./.tmuxinator.yml doesn't exist.".freeze
+    TMUX_MASTER_VERSION = 99.9
 
     class << self
       # The directory (created if needed) in which to store new projects
@@ -45,7 +46,15 @@ module Tmuxinator
       end
 
       def version
-        `tmux -V`.split(" ")[1].to_f if Tmuxinator::Doctor.installed?
+        if Tmuxinator::Doctor.installed?
+          tmux_version = `tmux -V`.split(" ")[1]
+
+          if tmux_version == "master"
+            TMUX_MASTER_VERSION
+          else
+            tmux_version.to_f
+          end
+        end
       end
 
       def default_path_option

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -143,6 +143,26 @@ describe Tmuxinator::Config do
     end
   end
 
+  describe "#version" do
+    subject { Tmuxinator::Config.version }
+
+    before do
+      expect(Tmuxinator::Doctor).to receive(:installed?).and_return(true)
+      allow_any_instance_of(Kernel).to receive(:`).with(/tmux\s\-V/).
+        and_return("tmux #{version}")
+    end
+
+    context "master" do
+      let(:version) { "master" }
+      it { is_expected.to eq 99.9 }
+    end
+
+    context "installed" do
+      let(:version) { "2.4" }
+      it { is_expected.to eq version.to_f }
+    end
+  end
+
   describe "#default_path_option" do
     context ">= 1.8" do
       before do


### PR DESCRIPTION
In https://github.com/tmuxinator/tmuxinator/issues/524#issuecomment-312065082, commenter @techgaun makes a good point about `tmux` `master` not failing (IIRC there was an issue for this item specifically, but I can't seem to find it ATM).  This creates an admittedly-arbitrary numeric value (99.9) to enable downstream invocations of `Tmuxinator::Config.version` to return a sensible value 

## Context

Currently, if `tmux` is built from scratch from the `master` branch, `tmux -V` returns `tmux master`, which resolves numerically to `0.0`.  This is both factually incorrect (as of this writing, `tmux`'s master branch is based off of `2.5`) and misleading (as it implies that `master` is an older version than, say `2.5`).  I'm open to other suggestions on how to deal with this, but figured this is a relatively easy solution (again, I think I saw someone else suggest it; they deserve the credit).

The use of 99.9 is, as indicated, clearly arbitrary.  My thinking is that it's fair to assume that `master` should be considered as equal-to-or-greater-than the highest published version, and that, for `tmuxinator`'s purposes, as detecting same is to handle "API" changes as `tmux` ages, this should be sufficient.  Again, open to other ideas here...