### PR TITLE
Set pane name when hash is passed to panes config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vagrant
 *.gem
 *.rbc
 .bundle
@@ -17,3 +18,4 @@ tmp
 db
 vendor/
 tags
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
   Exclude:
   - "vendor/**/*"
   - "db/schema.rb"
+  - "Vagrantfile"
   DisplayCopNames: true
   StyleGuideCopsOnly: false
 Rails:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,8 +64,10 @@ Vagrant.configure("2") do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install -y rubygems make gcc ruby-dev tmux
+    gem install bundler
+    gem install rake
+  SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,71 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "bento/ubuntu-16.04"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    # vb.gui = true
+  
+    # Customize the amount of memory on the VM:
+    # vb.memory = "1024"
+    vb.linked_clone = true
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -1,9 +1,10 @@
 module Tmuxinator
   class Pane
-    attr_reader :commands, :project, :index, :tab
+    attr_reader :project, :index, :tab
 
-    def initialize(index, project, tab, *commands)
+    def initialize(index, title, project, tab, *commands)
       @commands = commands
+      @title = title
       @index = index
       @project = project
       @tab = tab
@@ -29,8 +30,19 @@ module Tmuxinator
       end
     end
 
+    def commands
+      if @title != nil
+        [
+          "printf '\\033]2;#{@title}\\033\\\\'",
+          "clear"
+        ] + @commands
+      else
+        @commands
+      end
+    end
+
     def name
-      project.name
+      @title or project.name
     end
 
     def window_index

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -31,7 +31,7 @@ module Tmuxinator
     end
 
     def commands
-      if @title != nil
+      if @title.nil?
         [
           "printf '\\033]2;#{@title}\\033\\\\'",
           "clear"
@@ -42,7 +42,7 @@ module Tmuxinator
     end
 
     def name
-      @title or project.name
+      @title || project.name
     end
 
     def window_index

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -31,7 +31,7 @@ module Tmuxinator
     end
 
     def commands
-      if @title.nil?
+      if !@title.nil?
         [
           "printf '\\033]2;#{@title}\\033\\\\'",
           "clear"

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -58,8 +58,12 @@ module Tmuxinator
                     else
                       pane_yml
                     end
-
-        Tmuxinator::Pane.new(index, project, self, *commands)
+        # The pane key serves as a pane title
+        title = nil
+        if pane_yml.is_a?(Hash)
+          title = pane_yml.keys.first
+        end
+        Tmuxinator::Pane.new(index, title, project, self, *commands)
       end.flatten
     end
 

--- a/spec/lib/tmuxinator/pane_spec.rb
+++ b/spec/lib/tmuxinator/pane_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Tmuxinator::Pane do
   let(:klass) { described_class }
-  let(:instance) { klass.new(index, project, window, *commands) }
+  let(:instance) { klass.new(index, nil, project, window, *commands) }
   # let(:index) { "vim" }
   # let(:project) { 0 }
   # let(:tab) { nil }

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -138,7 +138,11 @@ describe Tmuxinator::Window do
         it "returns two panes in an Array" do
           expect(window.panes).to match [
             a_pane.with(index: 0).and_commands("vim"),
-            a_pane.with(index: 1).and_commands(command1, command2)
+            a_pane.with(index: 1).and_commands(
+              # Expects the pane title to be set to "pane2"
+              "printf '\\033]2;pane2\\033\\\\'", "clear",
+              command1, command2
+            )
           ]
         end
       end


### PR DESCRIPTION
# Motivation

tmux allows setting pane titles and with the `set-option set-title on` it is possible to pass these on to the terminal emulator e.g konsole, gnome-terminal, etc.

[man tmux](http://manpages.ubuntu.com/manpages/precise/en/man1/tmux.1.html)
>When a pane is first created, its title is the hostname.  A pane's title
>can be set via the OSC title setting sequence, for example:
>
>           $ printf '\033]2;My Title\033\\'

# Example config

```yaml
windows:
  - editor:
      pre:
        - echo "I get run in each pane, before each pane command!"
        -
      layout: main-vertical
      panes:
        - vim
        - #empty, will just run plain bash
        - top
        # The following pane will have the name of the hash/dict
        - pane_with_multiple_commands:
            - ssh server
            - echo "Hello"
```

# Result

When calling `display-message -p "#{pane_title}"` in tmux, the pane title (or the window title if the pane title isn't set) is returned

Tests have been added and rubocop is ok with it too.

# Extra

I was running on windows machine and had no way of testing, so I added a `Vagrantfile` with the bare minimum.