### PR TITLE
Remove confusing README section on base indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+- Remove confusing README section about the pane-base-index and
+  window-base-index options. These options can be set independently of one
+  another now that #542 and #543 are merged.
+
 ## 0.10.0
 - Fix a bug causing the user's global pane-base-index setting not to be
   respected

--- a/README.md
+++ b/README.md
@@ -33,14 +33,6 @@ export EDITOR='vim'
 The recommended version of tmux to use is 1.8 or later, with the exception of 2.5, which is **not** supported (see [issue 536](https://github.com/tmuxinator/tmuxinator/issues/536) for details). Your mileage may vary for
 earlier versions. Refer to the FAQ for any odd behaviour.
 
-### base-index
-
-If you use a `base-index` other than the default, please be sure to also set the `pane-base-index`
-
-```
-set-window-option -g pane-base-index 1
-```
-
 ## Completion
 
 Download the appropriate completion file from the repo and `source` the file.


### PR DESCRIPTION
Remove confusing README section about the pane-base-index and window-base-index options. These options can be set independently of one another now that #542 and #543 are merged.