### PR TITLE
When tmux is installed from a github clone, assume the later behavior rather than the earlier.

### DIFF
--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -49,7 +49,7 @@ module Tmuxinator
       end
 
       def default_path_option
-        version && version < 1.8 ? "default-path" : "-c"
+        version > 0 && version < 1.8 ? "default-path" : "-c"
       end
 
       def exists?(name)

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -154,6 +154,16 @@ describe Tmuxinator::Config do
       end
     end
 
+    context "0.0 (master cloned)" do
+      before do
+        allow(Tmuxinator::Config).to receive(:version).and_return(0.0)
+      end
+
+      it "returns -c" do
+        expect(Tmuxinator::Config.default_path_option).to eq "-c"
+      end
+    end
+
     context "< 1.8" do
       before do
         allow(Tmuxinator::Config).to receive(:version).and_return(1.7)


### PR DESCRIPTION
Were a user to install Tmux from a clone from github, the version returned is not a version number:

```bash
$ tmux -V
tmux master
```

When attempting to convert the string `master` into a valid version number, Ruby's `to_f` returns `0.0`; this causes Tmuxinator to assume that the version number is _earlier_ than 1.8 (released in 2014) rather than later.  It seems reasonable to assume that were `0.0` returned, that the user is using a recent clone.  

This is the root of at least one existing issue: https://github.com/tmuxinator/tmuxinator/issues/566