### PR TITLE
Add new tmux version to TravisCI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - "2.4.2"
 env:
   - TMUX_VERSION=master
+  - TMUX_VERSION=2.6
+  - TMUX_VERSION=2.5
+  - TMUX_VERSION=2.4
   - TMUX_VERSION=2.3
   - TMUX_VERSION=2.2
   - TMUX_VERSION=2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Handle emojis in project names (#564)
+- Add tmux 2.4, 2.5, and 2.6 to the TravisCI test matrix
 
 ## 0.10.0
 - Fix a bug causing the user's global pane-base-index setting not to be


### PR DESCRIPTION
Adding tmux versions 2.4, 2.5, and 2.6 to the
TravisCI matrix.