### PR TITLE
Fix additional pane-base-index bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 - Handle emojis in project names (#564)
+- Fix remaining sites where the base-index option (for windows) was incorrectly
+  used in place of the pane-base-index option.
 
 ## 0.10.0
 - Fix a bug causing the user's global pane-base-index setting not to be

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -38,7 +38,7 @@ module Tmuxinator
     end
 
     def pane_index
-      index + tab.project.base_index
+      index + tab.project.pane_base_index
     end
 
     def tmux_split_command

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -129,7 +129,7 @@ module Tmuxinator
     end
 
     def tmux_select_first_pane
-      "#{project.tmux} select-pane -t #{tmux_window_target}.#{panes.first.index + project.base_index}"
+      "#{project.tmux} select-pane -t #{tmux_window_target}.#{panes.first.index + project.pane_base_index}"
     end
 
     def synchronize_before?

--- a/spec/lib/tmuxinator/pane_spec.rb
+++ b/spec/lib/tmuxinator/pane_spec.rb
@@ -15,6 +15,7 @@ describe Tmuxinator::Pane do
   before do
     allow(project).to receive(:name).and_return "foo"
     allow(project).to receive(:base_index).and_return 0
+    allow(project).to receive(:pane_base_index).and_return 1
 
     allow(window).to receive(:project).and_return project
     allow(window).to receive(:index).and_return 0
@@ -26,5 +27,5 @@ describe Tmuxinator::Pane do
     expect(subject).to be_a(Tmuxinator::Pane)
   end
 
-  it { expect(subject.tmux_window_and_pane_target).to eql "foo:0.0" }
+  it { expect(subject.tmux_window_and_pane_target).to eql "foo:0.1" }
 end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -60,6 +60,7 @@ describe Tmuxinator::Window do
       tmux: "tmux",
       name: "test",
       base_index: 1,
+      pane_base_index: 0,
       root: "/project/tmuxinator",
       root?: true
     )
@@ -367,6 +368,12 @@ describe Tmuxinator::Window do
       it "does not set name option" do
         expect(window.tmux_new_window_command).to eq full_command
       end
+    end
+  end
+
+  describe "#tmux_select_first_pane" do
+    it "targets the pane based on the configured pane_base_index" do
+      expect(window.tmux_select_first_pane).to eq("tmux select-pane -t test:1.0")
     end
   end
 end


### PR DESCRIPTION
Fixes remaining sites where the base-index option (for windows) was incorrectly used in place of the pane-base-index option. This was causing some commands to be mis-targeted as I was setting up new projects.