### PR TITLE
Handle 'tmux master' version more gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - "2.3.5"
   - "2.4.2"
 env:
-  - TMUX_VERSION=master
   - TMUX_VERSION=2.3
   - TMUX_VERSION=2.2
   - TMUX_VERSION=2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 - Handle emojis in project names (#564)
 - Treat 'tmux master' as an arbitrarily high version and display a deprecation
-  warning.
+  warning for unsupported tmux versions (#524, #570)
 
 ## 0.10.0
 - Fix a bug causing the user's global pane-base-index setting not to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 - Handle emojis in project names (#564)
+- Treat 'tmux master' as an arbitrarily high version and display a deprecation
+  warning.
 
 ## 0.10.0
 - Fix a bug causing the user's global pane-base-index setting not to be

--- a/lib/tmuxinator.rb
+++ b/lib/tmuxinator.rb
@@ -6,6 +6,20 @@ require "thor/version"
 require "xdg"
 require "yaml"
 
+module Tmuxinator
+  SUPPORTED_TMUX_VERSIONS = [
+    1.5,
+    1.6,
+    1.7,
+    1.8,
+    1.9,
+    2.0,
+    2.1,
+    2.2,
+    2.3
+  ].freeze
+end
+
 require "tmuxinator/util"
 require "tmuxinator/deprecations"
 require "tmuxinator/wemux_support"
@@ -18,6 +32,3 @@ require "tmuxinator/pane"
 require "tmuxinator/project"
 require "tmuxinator/window"
 require "tmuxinator/version"
-
-module Tmuxinator
-end

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -3,6 +3,7 @@ module Tmuxinator
     LOCAL_DEFAULT = "./.tmuxinator.yml".freeze
     NO_LOCAL_FILE_MSG =
       "Project file at ./.tmuxinator.yml doesn't exist.".freeze
+    TMUX_MASTER_VERSION = Float::INFINITY
 
     class << self
       # The directory (created if needed) in which to store new projects
@@ -45,7 +46,15 @@ module Tmuxinator
       end
 
       def version
-        `tmux -V`.split(" ")[1].to_f if Tmuxinator::Doctor.installed?
+        if Tmuxinator::Doctor.installed?
+          tmux_version = `tmux -V`.split(" ")[1]
+
+          if tmux_version == "master"
+            TMUX_MASTER_VERSION
+          else
+            tmux_version.to_f
+          end
+        end
       end
 
       def default_path_option

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -35,11 +35,9 @@ module Tmuxinator
     not be supported anymore.
     M
     TMUX_MASTER_DEP_MSG = <<-M
-    DEPRECATION: you are running tmuxinator with an installed tmux version of
-    'master'. tmuxinator will attempt to treat this similarly to the latest
-    supported release, but since 'master' does not itself refer to a stable
-    release, it cannot be guaranteed support. Please consider using a supported
-    version of tmux.
+    DEPRECATION: You are running tmuxinator with an unsupported version of tmux.
+    Please consider using a supported version:
+    (#{Tmuxinator::SUPPORTED_TMUX_VERSIONS.join(', ')})
     M
 
     attr_reader :yaml
@@ -279,7 +277,7 @@ module Tmuxinator
         legacy_synchronize?,
         pre?,
         post?,
-        master?
+        unsupported_version?
       ]
     end
 
@@ -323,8 +321,8 @@ module Tmuxinator
       yaml["post"]
     end
 
-    def master?
-      Tmuxinator::Config.version == Tmuxinator::Config::TMUX_MASTER_VERSION
+    def unsupported_version?
+      !Tmuxinator::SUPPORTED_TMUX_VERSIONS.include?(Tmuxinator::Config.version)
     end
 
     def get_pane_base_index

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -34,6 +34,13 @@ module Tmuxinator
     DEPRECATION: the post option has been replaced by project hooks and will
     not be supported anymore.
     M
+    TMUX_MASTER_DEP_MSG = <<-M
+    DEPRECATION: you are running tmuxinator with an installed tmux version of
+    'master'. tmuxinator will attempt to treat this similarly to the latest
+    supported release, but since 'master' does not itself refer to a stable
+    release, it cannot be guaranteed support. Please consider using a supported
+    version of tmux.
+    M
 
     attr_reader :yaml
     attr_reader :force_attach
@@ -271,7 +278,8 @@ module Tmuxinator
         cli_args?,
         legacy_synchronize?,
         pre?,
-        post?
+        post?,
+        master?
       ]
     end
 
@@ -282,7 +290,8 @@ module Tmuxinator
         CLIARGS_DEP_MSG,
         SYNC_DEP_MSG,
         PRE_DEP_MSG,
-        POST_DEP_MSG
+        POST_DEP_MSG,
+        TMUX_MASTER_DEP_MSG
       ]
     end
 
@@ -312,6 +321,10 @@ module Tmuxinator
 
     def post?
       yaml["post"]
+    end
+
+    def master?
+      Tmuxinator::Config.version == Tmuxinator::Config::TMUX_MASTER_VERSION
     end
 
     def get_pane_base_index

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -143,6 +143,26 @@ describe Tmuxinator::Config do
     end
   end
 
+  describe "#version" do
+    subject { Tmuxinator::Config.version }
+
+    before do
+      expect(Tmuxinator::Doctor).to receive(:installed?).and_return(true)
+      allow_any_instance_of(Kernel).to receive(:`).with(/tmux\s\-V/).
+        and_return("tmux #{version}")
+    end
+
+    context "master" do
+      let(:version) { "master" }
+      it { is_expected.to eq Float::INFINITY }
+    end
+
+    context "installed" do
+      let(:version) { "2.4" }
+      it { is_expected.to eq version.to_f }
+    end
+  end
+
   describe "#default_path_option" do
     context ">= 1.8" do
       before do


### PR DESCRIPTION
Same diff as #545 with minor changes as discussed in that thread. Treats 'tmux master' as being arbitrarily high, and displays a deprecation warning to users attempting to run tmuxinator under 'tmux master'.