### PR TITLE
Add Support for Pane Title

### DIFF
--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -59,6 +59,9 @@ cd <%= root || "." %>
         <% if pane.tab.pre %>
   <%= pane.tmux_pre_command %>
         <% end %>
+        
+        <% if pane.title %><%= tmux  %> select-pane -t <%= pane.tmux_window_and_pane_target %> -T <%= pane.title %><% end %>
+
         <% pane.commands.each do |command| %>
   <%= pane.tmux_main_command(command) %>
         <% end %>

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -1,12 +1,13 @@
 module Tmuxinator
   class Pane
-    attr_reader :commands, :project, :index, :tab
+    attr_reader :commands, :project, :index, :tab, :title
 
-    def initialize(index, project, tab, *commands)
+    def initialize(index, project, tab, *commands, title)
       @commands = commands
       @index = index
       @project = project
       @tab = tab
+      @title = title
     end
 
     def tmux_window_and_pane_target

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -58,8 +58,13 @@ module Tmuxinator
                     else
                       pane_yml
                     end
-
-        Tmuxinator::Pane.new(index, project, self, *commands)
+	title = case pane_yml
+                    when Hash
+                      pane_yml.keys.first
+                    else
+                      nil
+		    end
+        Tmuxinator::Pane.new(index, project, self, *commands, title)
       end.flatten
     end
 

--- a/spec/lib/tmuxinator/pane_spec.rb
+++ b/spec/lib/tmuxinator/pane_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Tmuxinator::Pane do
   let(:klass) { described_class }
-  let(:instance) { klass.new(index, project, window, *commands) }
+  let(:instance) { klass.new(index, project, window, *commands, title) }
   # let(:index) { "vim" }
   # let(:project) { 0 }
   # let(:tab) { nil }
@@ -11,6 +11,7 @@ describe Tmuxinator::Pane do
   let(:project) { double }
   let(:window) { double }
   let(:commands) { ["vim", "bash"] }
+  let(:title) { "pane_title" }
 
   before do
     allow(project).to receive(:name).and_return "foo"

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -88,14 +88,14 @@ describe Tmuxinator::Window do
 
   describe "#panes" do
     context "with a three element Array" do
-      let(:panes) { ["vim", "ls", "top"] }
+      let(:panes) { ["vim", "ls", "top", {'pane_title': ["pwd"]}] }
 
       it "creates three panes" do
-        expect(Tmuxinator::Pane).to receive(:new).exactly(3).times
+        expect(Tmuxinator::Pane).to receive(:new).exactly(4).times
         window.panes
       end
 
-      it "returns three panes" do
+      it "returns four panes" do
         expect(window.panes).to all be_a_pane.with(
           project: project, tab: window
         )
@@ -104,7 +104,8 @@ describe Tmuxinator::Window do
           [
             a_pane.with(index: 0).and_commands("vim"),
             a_pane.with(index: 1).and_commands("ls"),
-            a_pane.with(index: 2).and_commands("top")
+            a_pane.with(index: 2).and_commands("top"),
+            a_pane.with(index: 3).and_title("pane_title").and_commands("pwd")
           ]
         )
       end

--- a/spec/matchers/pane_matcher.rb
+++ b/spec/matchers/pane_matcher.rb
@@ -23,6 +23,11 @@ RSpec::Matchers.define :a_pane do
     @expected_attrs = attrs
   end
 
+  chain :with_title do |title|
+    @title = title
+  end
+  alias_method :and_title, :with_title
+
   chain :with_commands do |*expected|
     @commands = expected
   end


### PR DESCRIPTION
windows:
  - w1:
       panes:
         - pane_title:
            - ls
         - pwd
         - git status

If the pane yml is a Hash, then we can set the pane_title variable, which in turn can be used in "pane_border_format"

Ex: setw -g pane-border-format " [#{pane_index}:#{pane_title}#{?pane_synchronized, SYNC,}] #{pane_current_command} "
 