### PR TITLE
Allow YAML aliases to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Remove confusing README section about the pane-base-index and
   window-base-index options. These options can be set independently of one
   another now that #542 and #543 are merged.
+- Allow YAML Anchors & Aliases as per [spec](http://yaml.org/spec/1.2/spec.html#id2765878)
 
 ## 0.11.3
 ### Misc

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -54,7 +54,7 @@ module Tmuxinator
         @args = args
 
         content = Erubis::Eruby.new(raw_content).result(binding)
-        YAML.safe_load(content)
+        YAML.safe_load(content, [], [], true)
       rescue SyntaxError, StandardError => error
         raise "Failed to parse config file: #{error.message}"
       end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -105,4 +105,12 @@ FactoryBot.define do
 
     initialize_with { Tmuxinator::Project.new(file) }
   end
+
+  factory :project_with_alias, class: Tmuxinator::Project do
+    transient do
+      file { "spec/fixtures/sample_alias.yml" }
+    end
+
+    initialize_with { Tmuxinator::Project.load(file) }
+  end
 end

--- a/spec/fixtures/sample_alias.yml
+++ b/spec/fixtures/sample_alias.yml
@@ -1,0 +1,21 @@
+# ~/.tmuxinator/sample.yml
+# you can make as many tabs as you wish...
+
+defaults: &defaults
+  pre:
+    - echo "alias_is_working"
+
+name: sample_alias
+root: ~/test
+windows:
+  - editor:
+      <<: *defaults
+      layout: main-vertical
+      panes:
+        - vim
+        - #empty, will just run plain bash
+        - top
+        - pane_with_multiple_commands:
+            - ssh server
+            - echo "Hello"
+  - guard:

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -31,6 +31,10 @@ describe Tmuxinator::Project do
     FactoryBot.build(:nameless_window_project)
   end
 
+  let(:project_with_alias) do
+    FactoryBot.build(:project_with_alias)
+  end
+
   it "should include Hooks" do
     expect(project).to be_kind_of(Tmuxinator::Hooks::Project)
   end
@@ -60,6 +64,14 @@ describe Tmuxinator::Project do
         expect(rendered).to_not be_empty
         expect(rendered).to include("custom")
         expect(rendered).to_not include("sample")
+      end
+    end
+
+    context "with alias" do
+      it "renders the tmux config" do
+        rendered = project_with_alias.render
+        expect(rendered).to_not be_empty
+        expect(rendered).to include("alias_is_working")
       end
     end
   end


### PR DESCRIPTION
This functionality needs to be explicitly enabled with safe_load