### PR TITLE
Fix error when using wemux instead of tmux

### DIFF
--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -3,7 +3,6 @@ module Tmuxinator
     include Tmuxinator::Util
     include Tmuxinator::Deprecations
     include Tmuxinator::Hooks::Project
-    include Tmuxinator::WemuxSupport
 
     RBENVRVM_DEP_MSG = <<-M
     DEPRECATION: rbenv/rvm-specific options have been replaced by the
@@ -96,7 +95,7 @@ module Tmuxinator
       raise "Cannot force_attach and force_detach at the same time" \
         if @force_attach && @force_detach
 
-      load_wemux_overrides if wemux?
+      extend Tmuxinator::WemuxSupport if wemux?
     end
 
     def render
@@ -388,6 +387,10 @@ module Tmuxinator
 
     def parsed_parameters(parameters)
       parameters.is_a?(Array) ? parameters.join("; ") : parameters
+    end
+
+    def wemux?
+      yaml["tmux_command"] == "wemux"
     end
   end
 end

--- a/lib/tmuxinator/wemux_support.rb
+++ b/lib/tmuxinator/wemux_support.rb
@@ -1,33 +1,14 @@
 module Tmuxinator
   module WemuxSupport
-    COMMAND = "wemux".freeze
-
-    def wemux?
-      yaml["tmux_command"] == COMMAND
+    def render
+      Tmuxinator::Project.render_template(
+        Tmuxinator::Config.wemux_template,
+        binding
+      )
     end
 
-    def load_wemux_overrides
-      override_render!
-      override_commands!
-    end
-
-    def override_render!
-      class_eval do
-        define_method :render do
-          Tmuxinator::Project.render_template(
-            Tmuxinator::Config.wemux_template,
-            binding
-          )
-        end
-      end
-    end
-
-    def override_commands!
-      class_eval do
-        %i[name tmux].each do |m|
-          define_method(m) { COMMAND }
-        end
-      end
+    %i(name tmux).each do |m|
+      define_method(m) { "wemux" }
     end
   end
 end

--- a/spec/lib/tmuxinator/wemux_support_spec.rb
+++ b/spec/lib/tmuxinator/wemux_support_spec.rb
@@ -1,31 +1,12 @@
 require "spec_helper"
 
 describe Tmuxinator::WemuxSupport do
-  let(:klass) { Class.new { include Tmuxinator::WemuxSupport } }
+  let(:klass) { Class.new }
   let(:instance) { klass.new }
 
-  it { expect(instance).to respond_to :wemux? }
-  it { expect(instance).to respond_to :load_wemux_overrides }
-
-  describe "#load_wemux_overrides" do
-    before { instance.load_wemux_overrides }
-
-    it "adds a render method" do
-      expect(instance).to respond_to :render
-    end
-
-    it "adds a name method" do
-      expect(instance).to respond_to :name
-    end
-
-    it "adds a tmux method" do
-      expect(instance).to respond_to :tmux
-    end
-  end
+  before { instance.extend Tmuxinator::WemuxSupport }
 
   describe "#render" do
-    before { instance.load_wemux_overrides }
-
     it "renders the template" do
       expect(File).to receive(:read).at_least(:once) { "wemux ls 2>/dev/null" }
 
@@ -34,14 +15,10 @@ describe Tmuxinator::WemuxSupport do
   end
 
   describe "#name" do
-    before { instance.load_wemux_overrides }
-
     it { expect(instance.name).to eq "wemux" }
   end
 
   describe "#tmux" do
-    before { instance.load_wemux_overrides }
-
     it { expect(instance.tmux).to eq "wemux" }
   end
 end


### PR DESCRIPTION
Currently the following error is thrown when trying to use wemux instead of tmux:
> undefined method `class_eval' for <#Tmuxinator::Project:0x00000002931528>

This patch extend the current instance of `Tmuxinator::Project` only if wemux is detected without using `class_eval` and avoids this error completely.