### PR TITLE
Add project config file option to `tmuxinator start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   degenerate case (#597)
 - Introduce factory_bot, to replace factory_girl, which was renamed
   recently.
+### New Features
+- Add optional `--project-config=...` parameter to `tmuxinator start` (#595)
 
 ## 0.10.1
 - Handle emojis in project names (#564)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.11.0
 ### Misc
 - Make Config#xdg comment reference correct XDG variable and include example of
   degenerate case (#597)

--- a/README.md
+++ b/README.md
@@ -276,12 +276,14 @@ root: ~/<%= @settings["workspace"] %>
 This will fire up tmux with all the tabs and panes you configured, `start` is aliased to `s`.
 
 ```
-tmuxinator start [project] -n [name]
+tmuxinator start [project] -n [name] -p [project-config]
 ```
 
 If you use the optional `[name]` argument, it will start a new tmux session with the custom name provided. This is to enable reuse of a project without tmux session name collision.
 
 If there is a `./.tmuxinator.yml` file in the current working directory but not a named project file in `~/.tmuxinator`, tmuxinator will use the local file. This is primarily intended to be used for sharing tmux configurations in complex development environments.
+
+You can provide tmuxinator with a project config file using the optional `[project-config]` argument (e.g. `--project-config=path/to/my-project.yaml` or `-p path/to/my-project.yaml`). This option will override a `[project]` name (if provided) and a local tmuxinator file (if present).
 
 ## Shorthand
 

--- a/bin/tmuxinator
+++ b/bin/tmuxinator
@@ -9,7 +9,7 @@ name = ARGV[0] || nil
 if ARGV.empty? && Tmuxinator::Config.local?
   Tmuxinator::Cli.new.local
 elsif name && !Tmuxinator::Cli::COMMANDS.keys.include?(name.to_sym) &&
-      Tmuxinator::Config.exists?(name)
+      Tmuxinator::Config.exists?(name: name)
   Tmuxinator::Cli.new.start(name, *ARGV.drop(1))
 else
   Tmuxinator::Cli.start

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -164,9 +164,9 @@ module Tmuxinator
       end
 
       def create_project(project_options = {})
-        attach_opt = project_options[:attach]
-        attach = !attach_opt.nil? && attach_opt ? true : false
-        detach = !attach_opt.nil? && !attach_opt ? true : false
+        attach_opt = project_options.fetch(:attach) { false }
+        attach = attach_opt
+        detach = !attach_opt
 
         options = {
           args: project_options[:args],

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -272,12 +272,12 @@ module Tmuxinator
       new_config_path = Tmuxinator::Config.project(new)
 
       exit!("Project #{existing} doesn't exist!") \
-        unless Tmuxinator::Config.exists?(existing)
+        unless Tmuxinator::Config.exists?(name: existing)
 
-      new_exists = Tmuxinator::Config.exists?(new)
+      new_exists = Tmuxinator::Config.exists?(name: new)
       question = "#{new} already exists, would you like to overwrite it?"
       if !new_exists || yes?(question, :red)
-        say "Overwriting #{new}" if Tmuxinator::Config.exists?(new)
+        say "Overwriting #{new}" if Tmuxinator::Config.exists?(name: new)
         FileUtils.copy_file(existing_config_path, new_config_path)
       end
 
@@ -290,7 +290,7 @@ module Tmuxinator
 
     def delete(*projects)
       projects.each do |project|
-        if Tmuxinator::Config.exists?(project)
+        if Tmuxinator::Config.exists?(name: project)
           config = Tmuxinator::Config.project(project)
 
           if yes?("Are you sure you want to delete #{project}?(y/n)", :red)

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -169,11 +169,12 @@ module Tmuxinator
         detach = !attach_opt.nil? && !attach_opt ? true : false
 
         options = {
+          args: project_options[:args],
+          custom_name: project_options[:custom_name],
           force_attach: attach,
           force_detach: detach,
           name: project_options[:name],
-          custom_name: project_options[:custom_name],
-          args: project_options[:args]
+          yaml_filepath: project_options[:yaml_filepath]
         }
 
         begin
@@ -206,13 +207,16 @@ module Tmuxinator
                            desc: "Attach to tmux session after creation."
     method_option :name, aliases: "-n",
                          desc: "Give the session a different name"
+    method_option :yaml_filepath, aliases: "-y",
+                         desc: "Project YAML filepath"
 
-    def start(name, *args)
+    def start(name = nil, *args)
       params = {
-        name: name,
-        custom_name: options[:name],
+        args: args,
         attach: options[:attach],
-        args: args
+        custom_name: options[:name],
+        name: name,
+        yaml_filepath: options[:yaml_filepath]
       }
       project = create_project(params)
       render_project(project)

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -164,6 +164,10 @@ module Tmuxinator
       end
 
       def create_project(project_options = {})
+        # Strings provided to --attach are coerced into booleans by Thor.
+        # "f" and "false" will result in `:attach` being `false` and any other
+        # string or the empty flag will result in `:attach` being `true`.
+        # If the flag is not present, `:attach` will be `nil`.
         attach = detach = false
         attach = true if project_options[:attach] == true
         detach = true if project_options[:attach] == false

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -17,8 +17,8 @@ module Tmuxinator
       edit: "Alias of new",
       open: "Alias of new",
       start: %w{
-        Start a tmux session using a project's tmuxinator config,
-        with an optional [ALIAS] for project reuse
+        Start a tmux session using a project's name (with an optional [ALIAS]
+        for project reuse) or a path to a project config file (via the -p flag)
       }.join(" "),
       stop: "Stop a tmux session using a project's tmuxinator config",
       local: "Start a tmux session using ./.tmuxinator.yml",

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -174,7 +174,7 @@ module Tmuxinator
           force_attach: attach,
           force_detach: detach,
           name: project_options[:name],
-          yaml_filepath: project_options[:yaml_filepath]
+          project_config: project_options[:project_config]
         }
 
         begin
@@ -207,8 +207,8 @@ module Tmuxinator
                            desc: "Attach to tmux session after creation."
     method_option :name, aliases: "-n",
                          desc: "Give the session a different name"
-    method_option :yaml_filepath, aliases: "-y",
-                         desc: "Project YAML filepath"
+    method_option "project-config", aliases: "-p",
+                                    desc: "Path to project config file"
 
     def start(name = nil, *args)
       params = {
@@ -216,8 +216,9 @@ module Tmuxinator
         attach: options[:attach],
         custom_name: options[:name],
         name: name,
-        yaml_filepath: options[:yaml_filepath]
+        project_config: options["project-config"]
       }
+
       project = create_project(params)
       render_project(project)
     end

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -164,9 +164,9 @@ module Tmuxinator
       end
 
       def create_project(project_options = {})
-        attach_opt = project_options.fetch(:attach) { false }
-        attach = attach_opt
-        detach = !attach_opt
+        attach = detach = false
+        attach = true if project_options[:attach] == true
+        detach = true if project_options[:attach] == false
 
         options = {
           args: project_options[:args],

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -3,6 +3,7 @@ module Tmuxinator
     LOCAL_DEFAULT = "./.tmuxinator.yml".freeze
     NO_LOCAL_FILE_MSG =
       "Project file at ./.tmuxinator.yml doesn't exist.".freeze
+    NO_EXPLICIT_YAML_FILEPATH_MSG = "Project file at FILEPATH doesn't exist.".freeze
     TMUX_MASTER_VERSION = Float::INFINITY
 
     class << self
@@ -71,6 +72,10 @@ module Tmuxinator
         local_project
       end
 
+      def explicit_yaml_filepath_exists?(filepath)
+        File.exist?(filepath)
+      end
+
       # Pathname of given project searching only global directories
       def global_project(name)
         project_in(environment, name) ||
@@ -127,8 +132,15 @@ module Tmuxinator
         name = options[:name]
         options[:force_attach] ||= false
         options[:force_detach] ||= false
+        yaml_filepath = options.fetch(:yaml_filepath) { false }
 
-        project_file = if name.nil?
+        project_file = if yaml_filepath
+                         raise NO_EXPLICIT_YAML_FILEPATH_MSG.gsub("FILEPATH",
+                                                                  yaml_filepath)\
+                           unless Tmuxinator::Config.
+                                    explicit_yaml_filepath_exists?(yaml_filepath)
+                         yaml_filepath
+                       elsif name.nil?
                          raise NO_LOCAL_FILE_MSG \
                            unless Tmuxinator::Config.local?
                          local_project

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "0.10.1".freeze
+  VERSION = "0.11.0".freeze
 end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -80,6 +80,13 @@ describe Tmuxinator::Cli do
         capture_io { cli.start }
       end
 
+      it "accepts a project config file flag" do
+        ARGV.replace(["start", "foo", "--project-config=sample.yml"])
+
+        expect(Kernel).to receive(:exec)
+        capture_io { cli.start }
+      end
+
       it "accepts additional arguments" do
         ARGV.replace(["start", "foo", "bar", "three=four"])
 
@@ -167,6 +174,29 @@ describe Tmuxinator::Cli do
       let(:project) { FactoryBot.build(:project) }
 
       it "starts the project" do
+        expect(Kernel).to receive(:exec)
+        capture_io { cli.start }
+      end
+    end
+  end
+
+  describe "#start(with project config flag)" do
+    before do
+      allow(Tmuxinator::Config).to receive_messages(version: 1.9)
+    end
+
+    let(:fixtures_dir) { File.expand_path("../../../fixtures/", __FILE__) }
+    let(:project_config) { File.join(fixtures_dir, "sample.yml") }
+
+    context "no deprecations" do
+      it "doesn't start the project if given a bogus project config" do
+        ARGV.replace(["start", "--project-config=bogus.yml"])
+        expect(Kernel).not_to receive(:exec)
+        expect { capture_io { cli.start } }.to raise_error(SystemExit)
+      end
+
+      it "starts the project if given a project config" do
+        ARGV.replace(["start", "--project-config=#{project_config}"])
         expect(Kernel).to receive(:exec)
         capture_io { cli.start }
       end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -493,8 +493,12 @@ describe Tmuxinator::Cli do
 
       context "only one project exists" do
         before do
-          allow(Tmuxinator::Config).to receive(:exists?).with("foo") { true }
-          allow(Tmuxinator::Config).to receive(:exists?).with("bar") { false }
+          allow(Tmuxinator::Config).to receive(:exists?).with(name: "foo") {
+            true
+          }
+          allow(Tmuxinator::Config).to receive(:exists?).with(name: "bar") {
+            false
+          }
         end
 
         it "deletes one project" do

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -653,17 +653,21 @@ describe Tmuxinator::Cli do
   end
 
   describe "#create_project" do
-    shared_examples_for :a_proper_project do
-      it "should create a valid project" do
-        expect(subject).to be_a Tmuxinator::Project
-        expect(subject.name).to eq name
-      end
+    before do
+      allow(Tmuxinator::Config).to receive_messages(directory: path)
     end
 
     let(:name) { "sample" }
     let(:custom_name) { nil }
     let(:cli_options) { {} }
     let(:path) { File.expand_path("../../../fixtures", __FILE__) }
+
+    shared_examples_for :a_proper_project do
+      it "should create a valid project" do
+        expect(subject).to be_a Tmuxinator::Project
+        expect(subject.name).to eq name
+      end
+    end
 
     context "when creating a traditional named project" do
       let(:params) do
@@ -674,11 +678,47 @@ describe Tmuxinator::Cli do
       end
       subject { described_class.new.create_project(params) }
 
-      before do
-        allow(Tmuxinator::Config).to receive_messages(directory: path)
+      it_should_behave_like :a_proper_project
+    end
+
+    context "attach option" do
+      describe "detach" do
+        it "sets force_detach to false when no attach argument is provided" do
+          project = Tmuxinator::Cli.new.create_project(name: name)
+          expect(project.force_detach).to eq(false)
+        end
+
+        it "sets force_detach to true when 'attach: false' is provided" do
+          project = Tmuxinator::Cli.new.create_project(attach: false,
+                                                       name: name)
+          expect(project.force_detach).to eq(true)
+        end
+
+        it "sets force_detach to false when 'attach: true' is provided" do
+          project = Tmuxinator::Cli.new.create_project(attach: true,
+                                                       name: name)
+          expect(project.force_detach).to eq(false)
+        end
       end
 
-      it_should_behave_like :a_proper_project
+      describe "attach" do
+        it "sets force_attach to false when no attach argument is provided" do
+          project = Tmuxinator::Cli.new.create_project(name: name)
+          expect(project.force_attach).to eq(false)
+        end
+
+        it "sets force_attach to true when 'attach: true' is provided" do
+          project = Tmuxinator::Cli.new.create_project(attach: true,
+                                                       name: name)
+          expect(project.force_attach).to eq(true)
+        end
+
+        it "sets force_attach to false when 'attach: false' is provided" do
+          project = Tmuxinator::Cli.new.create_project(attach: false,
+                                                       name: name)
+          expect(project.force_attach).to eq(false)
+        end
+      end
     end
   end
 

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -329,6 +329,21 @@ describe Tmuxinator::Config do
   describe "#validate" do
     let(:default) { Tmuxinator::Config::LOCAL_DEFAULT }
 
+    context "when a yaml filepath is provided" do
+      it "should raise if the yaml filepath can't be found" do
+        yaml_filepath = "dont-exist.yml"
+        expect do
+          Tmuxinator::Config.validate(yaml_filepath: yaml_filepath)
+        end.to raise_error RuntimeError, %r{Project file at #{yaml_filepath} doesn't exist\.}
+      end
+
+      it "should load and validate the project" do
+        yaml_filepath = File.join(fixtures_dir, "sample.yml")
+        expect(Tmuxinator::Config.validate(yaml_filepath: yaml_filepath)).to \
+          be_a Tmuxinator::Project
+      end
+    end
+
     context "when a project name is provided" do
       it "should raise if the project file can't be found" do
         expect do

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -342,6 +342,21 @@ describe Tmuxinator::Config do
         expect(Tmuxinator::Config.validate(project_config: project_config)).to \
           be_a Tmuxinator::Project
       end
+
+      it "should take precedence over a named project" do
+        allow(Tmuxinator::Config).to receive_messages(directory: fixtures_dir)
+        project_config = File.join(fixtures_dir, "sample_number_as_name.yml")
+        project = Tmuxinator::Config.validate(name: "sample",
+                                              project_config: project_config)
+        expect(project.name).to eq("222")
+      end
+
+      it "should take precedence over a local project" do
+        expect(Tmuxinator::Config).not_to receive(:local?)
+        project_config = File.join(fixtures_dir, "sample_number_as_name.yml")
+        project = Tmuxinator::Config.validate(project_config: project_config)
+        expect(project.name).to eq("222")
+      end
     end
 
     context "when a project name is provided" do

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -332,9 +332,10 @@ describe Tmuxinator::Config do
     context "when a project config file is provided" do
       it "should raise if the project config file can't be found" do
         project_config = "dont-exist.yml"
+        regex = /Project config \(#{project_config}\) doesn't exist\./
         expect do
           Tmuxinator::Config.validate(project_config: project_config)
-        end.to raise_error RuntimeError, /Project config file doesn't exist\./
+        end.to raise_error RuntimeError, regex
       end
 
       it "should load and validate the project" do
@@ -388,6 +389,18 @@ describe Tmuxinator::Config do
         expect(File).to receive(:read).with(default).and_return(content)
 
         expect(Tmuxinator::Config.validate).to be_a Tmuxinator::Project
+      end
+    end
+
+    context "when no project can be found" do
+      it "should raise with NO_PROJECT_FOUND_MSG" do
+        config = Tmuxinator::Config
+        expect(config).to receive(:valid_project_config?).and_return(false)
+        expect(config).to receive(:valid_local_project?).and_return(false)
+        expect(config).to receive(:valid_standard_project?).and_return(false)
+        expect do
+          Tmuxinator::Config.validate
+        end.to raise_error RuntimeError, %r{Project could not be found\.}
       end
     end
   end

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -238,7 +238,7 @@ describe Tmuxinator::Config do
     end
 
     it "checks if the given project exists" do
-      expect(Tmuxinator::Config.exists?("test")).to be_truthy
+      expect(Tmuxinator::Config.exists?(name: "test")).to be_truthy
     end
   end
 
@@ -329,17 +329,17 @@ describe Tmuxinator::Config do
   describe "#validate" do
     let(:default) { Tmuxinator::Config::LOCAL_DEFAULT }
 
-    context "when a yaml filepath is provided" do
-      it "should raise if the yaml filepath can't be found" do
-        yaml_filepath = "dont-exist.yml"
+    context "when a project config file is provided" do
+      it "should raise if the project config file can't be found" do
+        project_config = "dont-exist.yml"
         expect do
-          Tmuxinator::Config.validate(yaml_filepath: yaml_filepath)
-        end.to raise_error RuntimeError, %r{Project file at #{yaml_filepath} doesn't exist\.}
+          Tmuxinator::Config.validate(project_config: project_config)
+        end.to raise_error RuntimeError, /Project config file doesn't exist\./
       end
 
       it "should load and validate the project" do
-        yaml_filepath = File.join(fixtures_dir, "sample.yml")
-        expect(Tmuxinator::Config.validate(yaml_filepath: yaml_filepath)).to \
+        project_config = File.join(fixtures_dir, "sample.yml")
+        expect(Tmuxinator::Config.validate(project_config: project_config)).to \
           be_a Tmuxinator::Project
       end
     end


### PR DESCRIPTION
Users can now provide a project config file to `tmuxinator start` using the `--project-config` or `-p` flags. (e.g. `tmuxinator start -p my-project.yml`).

Addresses #595.