### PR TITLE
Always prefer local lib over other versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Fix load order when multiple versions of tmuxinator are installed (#603)
+
 ## 0.11.0
 ### Misc
 - Make Config#xdg comment reference correct XDG variable and include example of

--- a/bin/tmuxinator
+++ b/bin/tmuxinator
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-$: << File.expand_path("../../lib/", __FILE__)
+$:.unshift File.expand_path("../../lib/", __FILE__)
 
 require "thor"
 require "tmuxinator"


### PR DESCRIPTION
`>>` appends (to `LOAD_PATH`) instead of prepending, which means another installation might take precedence. This bug was introduced in 2903c70e.

With the current code, this happens for me:

~~~~
$ $GEM_HOME/gems/tmuxinator-0.10.1/bin/tmuxinator version
tmuxinator 0.8.1
~~~~