### PR TITLE
Fix zsh completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Remove confusing README section about the pane-base-index and
   window-base-index options. These options can be set independently of one
   another now that #542 and #543 are merged.
+- Fix zsh completion when there are no projects
 
 ## 0.11.3
 ### Misc

--- a/completion/tmuxinator.zsh
+++ b/completion/tmuxinator.zsh
@@ -4,8 +4,9 @@ _tmuxinator() {
   projects=(${(f)"$(tmuxinator completions start)"})
 
   if (( CURRENT == 2 )); then
-    _describe -t commands "tmuxinator subcommands" commands
-    _describe -t projects "tmuxinator projects" projects
+    _alternative \
+      'commands:: _describe -t commands "tmuxinator subcommands" commands' \
+      'projects:: _describe -t projects "tmuxinator projects" projects'
   elif (( CURRENT == 3)); then
     case $words[2] in
       copy|debug|delete|open|start)


### PR DESCRIPTION
## The Problem

If the user has no Tmuxinator projects, then this line:

```zsh
_describe -t projects "tmuxinator projects" projects
```

Will cause this chaos:

![badcompletion](https://user-images.githubusercontent.com/719733/38357823-8141d752-3878-11e8-8fd2-25fb6806489c.png)

Notice how the command descriptions are actual selectable completions, the random gaps, and, while not pictured, all output repeats a couple of times (notice the 126 total matches at the bottom).

## The Fix

Very minor change: If the `projects` array is empty, don't try to run the `_describe -t projects ...` line. This change fixes the erratic results in the above screenshot with the settings listed below.

Also, it's better not to run `_describe` if there's no need to, anyway. 😃

## Minimal Reproduction

With a brand new user, with shell set to `zsh`, and **no** Tmuxinator projects:

**.zshrc**

```zsh
autoload -Uz compinit && compinit
source '<path/to/tmuxinator.zsh>'

zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*'
```

Type 'mux' or 'tmuxinator', followed by a space, and then press `Tab`.