### PR TITLE
Fix on exit not firing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+- Fix [#555](https://github.com/tmuxinator/tmuxinator/issues/555), restoring
+  `on_project_exit` hook behaviour ( same as deprecated `post` )
+
 ## 0.11.1
 ### Misc
 - Add support for tmux 2.7 (#611)

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -94,7 +94,5 @@ cd <%= root || "." %>
 <%- end -%>
 
 <%= post %>
-<%- unless attach? -%>
-  # Run on_project_exit command.
-  <%= hook_on_project_exit %>
-<%- end -%>
+# Run on_project_exit command.
+<%= hook_on_project_exit %>


### PR DESCRIPTION
This PR should address #555, restoring `post`-like behaviour for `on_project_exit`.

That behaviour was prevented by the `unless attach?` check, which AFAICT is not useful in this case.