### PR TITLE
Local config overrides basic commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tmp
 db
 vendor/
 tags
+.env*
+.env

--- a/bin/tmuxinator
+++ b/bin/tmuxinator
@@ -4,4 +4,4 @@ $:.unshift File.expand_path("../../lib/", __FILE__)
 require "thor"
 require "tmuxinator"
 
-Tmuxinator::Cli.bootstrap *ARGV
+Tmuxinator::Cli.bootstrap ARGV

--- a/bin/tmuxinator
+++ b/bin/tmuxinator
@@ -4,13 +4,4 @@ $:.unshift File.expand_path("../../lib/", __FILE__)
 require "thor"
 require "tmuxinator"
 
-name = ARGV[0] || nil
-
-if ARGV.empty? && Tmuxinator::Config.local?
-  Tmuxinator::Cli.new.local
-elsif name && !Tmuxinator::Cli::RESERVED_COMMANDS.include?(name) &&
-      Tmuxinator::Config.exists?(name: name)
-  Tmuxinator::Cli.new.start(name, *ARGV.drop(1))
-else
-  Tmuxinator::Cli.start
-end
+Tmuxinator::Cli.bootstrap

--- a/bin/tmuxinator
+++ b/bin/tmuxinator
@@ -4,4 +4,4 @@ $:.unshift File.expand_path("../../lib/", __FILE__)
 require "thor"
 require "tmuxinator"
 
-Tmuxinator::Cli.bootstrap
+Tmuxinator::Cli.bootstrap *ARGV

--- a/bin/tmuxinator
+++ b/bin/tmuxinator
@@ -8,7 +8,7 @@ name = ARGV[0] || nil
 
 if ARGV.empty? && Tmuxinator::Config.local?
   Tmuxinator::Cli.new.local
-elsif name && !Tmuxinator::Cli::COMMANDS.keys.include?(name.to_sym) &&
+elsif name && !Tmuxinator::Cli::RESERVED_COMMANDS.include?(name) &&
       Tmuxinator::Config.exists?(name: name)
   Tmuxinator::Cli.new.start(name, *ARGV.drop(1))
 else

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -345,5 +345,17 @@ module Tmuxinator
       say "Checking if $SHELL is set ==> "
       yes_no Tmuxinator::Doctor.shell?
     end
+
+    def self.bootstrap(*args)
+      name = args[0] || nil
+      if args.empty? && Tmuxinator::Config.local?
+        Tmuxinator::Cli.new.local
+      elsif name && !Tmuxinator::Cli::RESERVED_COMMANDS.include?(name) &&
+            Tmuxinator::Config.exists?(name: name)
+        Tmuxinator::Cli.new.start(name, *args.drop(1))
+      else
+        Tmuxinator::Cli.start(*args)
+      end
+    end
   end
 end

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -364,7 +364,7 @@ module Tmuxinator
     # array or ARGV, not a varargs.  Perhaps ::bootstrap should as well?
     # - ::start has a different purpose from #start and hence a different
     # signature
-    def self.bootstrap(*args)
+    def self.bootstrap(args = [])
       name = args[0] || nil
       if args.empty? && Tmuxinator::Config.local?
         Tmuxinator::Cli.new.local

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -33,6 +33,7 @@ module Tmuxinator
       doctor: "Look for problems in your configuration",
       list: "Lists all tmuxinator projects"
     }.freeze
+    RESERVED_COMMANDS = (COMMANDS.keys + %w[-v help]).map(&:to_s).freeze
 
     package_name "tmuxinator" \
       unless Gem::Version.create(Thor::VERSION) < Gem::Version.create("0.18")

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -33,7 +33,17 @@ module Tmuxinator
       doctor: "Look for problems in your configuration",
       list: "Lists all tmuxinator projects"
     }.freeze
-    RESERVED_COMMANDS = (COMMANDS.keys + %w[-v help]).map(&:to_s).freeze
+
+    # For future reference: due to how tmuxinator currently consumes
+    # command-line arguments (see ::bootstrap, below), invocations of Thor's
+    # base commands (i.e. 'help', etc) can be instead routed to #start (rather
+    # than to ::start).  In order to prevent this, the THOR_COMMANDS and
+    # RESERVED_COMMANDS constants have been introduced. The former enumerates
+    # any/all Thor commands we want to insure get passed through to Thor.start.
+    # The latter is the superset of the Thor commands and any tmuxinator
+    # commands, defined in COMMANDS, above.
+    THOR_COMMANDS = %w[-v help].freeze
+    RESERVED_COMMANDS = (COMMANDS.keys + THOR_COMMANDS).map(&:to_s).freeze
 
     package_name "tmuxinator" \
       unless Gem::Version.create(Thor::VERSION) < Gem::Version.create("0.18")

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -346,6 +346,14 @@ module Tmuxinator
       yes_no Tmuxinator::Doctor.shell?
     end
 
+    # This method was defined as something of a workaround...  Previously
+    # the conditional contained within was in the executable (i.e.
+    # bin/tmuxinator).  It has been moved here so as to be testable. A couple
+    # of notes:
+    # - ::start (defined in Thor::Base) expects the first argument to be an
+    # array or ARGV, not a varargs.  Perhaps ::bootstrap should as well?
+    # - ::start has a different purpose from #start and hence a different
+    # signature
     def self.bootstrap(*args)
       name = args[0] || nil
       if args.empty? && Tmuxinator::Config.local?
@@ -354,7 +362,7 @@ module Tmuxinator
             Tmuxinator::Config.exists?(name: name)
         Tmuxinator::Cli.new.start(name, *args.drop(1))
       else
-        Tmuxinator::Cli.start(*args)
+        Tmuxinator::Cli.start(args)
       end
     end
   end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -43,13 +43,13 @@ describe Tmuxinator::Cli do
   context "base thor functionality" do
     shared_examples_for :base_thor_functionality do
       it "supports -v" do
-        out, err = capture_io { cli.bootstrap("-v") }
+        out, err = capture_io { cli.bootstrap(["-v"]) }
         expect(err).to eq ""
         expect(out).to include(Tmuxinator::VERSION)
       end
 
       it "supports help" do
-        out, err = capture_io { cli.bootstrap("help") }
+        out, err = capture_io { cli.bootstrap(["help"]) }
         expect(err).to eq ""
         expect(out).to include("tmuxinator commands:")
       end
@@ -65,7 +65,7 @@ describe Tmuxinator::Cli do
   end
 
   describe "::bootstrap" do
-    subject { cli.bootstrap(*args) }
+    subject { cli.bootstrap(args) }
     let(:args) { [] }
 
     shared_examples_for :bootstrap_with_arguments do

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -3,9 +3,13 @@ require "spec_helper"
 describe Tmuxinator::Cli do
   shared_context :local_project_setup do
     let(:local_project_config) { ".tmuxinator.yml" }
-    let(:content) { File.read(File.expand_path(File.join(File.dirname(__FILE__), "../../fixtures/sample.yml"))) }
+    let(:content_fixture) { "../../fixtures/sample.yml" }
+    let(:content_relpath) { File.join(File.dirname(__FILE__), content_fixture) }
+    let(:content_path) { File.expand_path(content_relpath) }
+    let(:content) { File.read(content_path) }
     let(:working_dir) { FileUtils.pwd }
-    let(:local_project_path) { File.expand_path(File.join(working_dir, local_project_config)) }
+    let(:local_project_relpath) { File.join(working_dir, local_project_config) }
+    let(:local_project_path) { File.expand_path(local_project_relpath) }
 
     before do
       File.new(local_project_path, "w").tap do |f|
@@ -60,7 +64,6 @@ describe Tmuxinator::Cli do
     end
   end
 
-
   describe "::bootstrap" do
     subject { cli.bootstrap(*args) }
     let(:args) { [] }
@@ -82,7 +85,8 @@ describe Tmuxinator::Cli do
 
         context "a tmuxinator project name" do
           before do
-            expect(Tmuxinator::Config).to receive(:exists?).with(name: arg1) { true }
+            expect(Tmuxinator::Config).to \
+              receive(:exists?).with(name: arg1) { true }
           end
 
           it "should call #start" do
@@ -115,7 +119,8 @@ describe Tmuxinator::Cli do
 
         context "something else" do
           before do
-            expect(Tmuxinator::Config).to receive(:exists?).with(name: arg1) { false }
+            expect(Tmuxinator::Config).to \
+              receive(:exists?).with(name: arg1) { false }
           end
 
           it "should call ::start" do

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -44,7 +44,7 @@ describe Tmuxinator::Cli do
         expect(out).to include(Tmuxinator::VERSION)
       end
 
-      xit "supports help" do
+      it "supports help" do
         out, err = capture_io { cli.bootstrap("help") }
         expect(err).to eq ""
         expect(out).to include("tmuxinator commands:")
@@ -56,8 +56,7 @@ describe Tmuxinator::Cli do
     context "with a local project config" do
       include_context :local_project_setup
 
-      # it_should_behave_like :base_thor_functionality
-      # it { expect(true).to be_truthy }
+      it_should_behave_like :base_thor_functionality
     end
   end
 
@@ -73,7 +72,7 @@ describe Tmuxinator::Cli do
         let(:arg1) { "list" }
 
         it "should call ::start" do
-          expect(cli).to receive(:start).with(*args)
+          expect(cli).to receive(:start).with(args)
           subject
         end
       end
@@ -95,15 +94,11 @@ describe Tmuxinator::Cli do
         end
 
         context "a thor command" do
-          before do
-            # allow(Tmuxinator::Config).to receive(:version){ 2.4 }
-          end
-
           context "(-v)" do
             let(:arg1) { "-v" }
 
             it "should call ::start" do
-              expect(cli).to receive(:start).with(*args)
+              expect(cli).to receive(:start).with(args)
               subject
             end
           end
@@ -112,7 +107,7 @@ describe Tmuxinator::Cli do
             let(:arg1) { "help" }
 
             it "should call ::start" do
-              expect(cli).to receive(:start).with(*args)
+              expect(cli).to receive(:start).with(args)
               subject
             end
           end
@@ -124,7 +119,7 @@ describe Tmuxinator::Cli do
           end
 
           it "should call ::start" do
-            expect(cli).to receive(:start).with(*args)
+            expect(cli).to receive(:start).with(args)
             subject
           end
         end
@@ -151,7 +146,7 @@ describe Tmuxinator::Cli do
     context "and there is no local project config" do
       context "when no args are supplied" do
         it "should call ::start" do
-          expect(cli).to receive(:start).with(no_args)
+          expect(cli).to receive(:start).with([])
           subject
         end
       end


### PR DESCRIPTION
FIXES https://github.com/tmuxinator/tmuxinator/issues/431

## Problem

Branching logic in `bin/tmuxinator` caused commands that would normally fall through to the base `thor` implementation (e.g. `-v`, `help`) to be consumed by the `tmuxinator` startup, which produced some weird behavior.

## Solution

- Moves branching logic to `Tmuxinator::Cli.bootstrap`, to enable testing.
- Refactors command lookup:
  - Creates `RESERVED_COMMANDS`, which is the superset of `tmuxinator` commands (i.e. existing functionality) and `thor` commands (at least, those explicitly denoted in the issue).

## Next Steps

While this is a decent stopgap, IMO the CLI implementation is getting pretty convoluted.  I'm thinking that perhaps I will spike on a better long-term solution...  Prolly splitting the CLI into 3 or 4 parts:

- Base functionality (`list`, `commands`, etc)
- Project functionality using centralized config location
- Project functionality using local config location (i.e. `--local`)
- Wemux functionality

Or something along those lines... I think it would decrease complexity and facilitate an easier debugging experience.  Opinions welcome.

