### PR TITLE
Run stop hook before killing the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   another now that #542 and #543 are merged.
 - Fix zsh completion when there are no projects
 - Allow YAML Anchors & Aliases as per [spec](http://yaml.org/spec/1.2/spec.html#id2765878)
+- Run stop hook before killing the session
 
 ## 0.11.3
 ### Misc

--- a/lib/tmuxinator/assets/template-stop.erb
+++ b/lib/tmuxinator/assets/template-stop.erb
@@ -3,9 +3,8 @@
 <%- if tmux_has_session? name -%>
   cd <%= root || "." %>
 
-  <%= tmux_kill_session_command %>
-  
   # Run on_project_stop command
   <%= hook_on_project_stop %>
 
+  <%= tmux_kill_session_command %>
 <%- end -%>


### PR DESCRIPTION
Hello! 😄 

After noticing that my `on_project_stop` hook was not running correctly when I exited my session (with `tmuxinator stop`), I then tried to find someone with the same issue as me. I soon found #555, and though it touched this issue, it went back and forth on other things and eventually reached a bug that was preventing the `on_project_exit` hook from running at all.

From the issue I saw that the `on_project_stop` hook would run if I ran the `tmuxinator stop` command from outside the tmux session, but to me that is not ideal, because in my workflow, while I'm working on a project, I never exit that session until I end my work, so it's natural to stop the project from the session itself (and surely I can't be the only one that does that 😰).
Because the OP was trying to exit with `kill-session`, this bug being fixed ended up being their solution, as well as moving their command to the `on_project_exit` hook.

So I searched some more and found #486, as well as this comment https://github.com/tmuxinator/tmuxinator/pull/486#issuecomment-265267067.
>  * I think `hook_on_stop` _may_ need to be moved before `tmux_kill_session_command`. On my system (Debian 8.6, Bash 4.3.30, Tmux 1.9, Ruby 2.3.1p112) `on_stop` commands are ignored unless I reverse these two method calls. Is this working for you?

Bingo. From what I could understand from the source code, the `tmuxinator stop` command actually execs into a script generated on the fly, which is the file with the commands to which the comment refers, and so by swapping the tmux kill session command with the hook method call on that template (`template-stop.erb`), I could make my `on_project_stop` work fine, even when running `tmuxinator stop` from inside the session itself.

So I decided to open this micro PR implementing the change described in the comment (that appears to have been accidentally left out from the original PR). I tried to write some small test, but since `Project#kill` is actually exec'd, I couldn't find a way to test that. But the only effect this should have is running the stop command before killing the tmux session instead of the other way around.