### PR TITLE
639-pass-all-optargs-through-when-using-project-config-flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Bugfixes
+- prevent optargs from being lost when using the project-config flag (#639)
+
 ## 0.12.0
 ### Bugfixes
 - Fix zsh completion when there are no projects

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -226,6 +226,13 @@ module Tmuxinator
                                     desc: "Path to project config file"
 
     def start(name = nil, *args)
+      # project-config takes precedence over a named project in the case that
+      # both are provided.
+      if options["project-config"]
+        args.unshift name
+        name = nil
+      end
+
       params = {
         args: args,
         attach: options[:attach],

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -229,7 +229,7 @@ module Tmuxinator
       # project-config takes precedence over a named project in the case that
       # both are provided.
       if options["project-config"]
-        args.unshift name
+        args.unshift name if name
         name = nil
       end
 

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -344,6 +344,22 @@ describe Tmuxinator::Cli do
         expect(Kernel).to receive(:exec)
         capture_io { cli.start }
       end
+
+      it "passes additional arguments through" do
+        ARGV.replace(["start", "--project-config=#{project_config}", "extra"])
+        expect(Tmuxinator::Config).
+          to(receive(:validate).
+             with(hash_including(args: array_including("extra"))))
+        capture_io { cli.start }
+      end
+
+      it "does not set the project name" do
+        ARGV.replace(["start", "--project-config=#{project_config}"])
+        expect(Tmuxinator::Config).
+          to(receive(:validate).
+             with(hash_including(name: nil)))
+        capture_io { cli.start }
+      end
     end
   end
 

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -326,23 +326,25 @@ describe Tmuxinator::Cli do
 
   describe "#start(with project config flag)" do
     before do
+      allow(Tmuxinator::Config).to receive(:validate).and_call_original
       allow(Tmuxinator::Config).to receive_messages(version: 1.9)
+      allow(Kernel).to receive(:exec)
     end
 
-    let(:fixtures_dir) { File.expand_path("../../../fixtures/", __FILE__) }
-    let(:project_config) { File.join(fixtures_dir, "sample.yml") }
-
     context "no deprecations" do
-      it "doesn't start the project if given a bogus project config" do
-        ARGV.replace(["start", "--project-config=bogus.yml"])
-        expect(Kernel).not_to receive(:exec)
-        expect { capture_io { cli.start } }.to raise_error(SystemExit)
-      end
+      let(:fixtures_dir) { File.expand_path("../../../fixtures/", __FILE__) }
+      let(:project_config) { File.join(fixtures_dir, "sample.yml") }
 
-      it "starts the project if given a project config" do
+      it "starts the project if given a valid project config" do
         ARGV.replace(["start", "--project-config=#{project_config}"])
         expect(Kernel).to receive(:exec)
         capture_io { cli.start }
+      end
+
+      it "does not start the project if given a bogus project config" do
+        ARGV.replace(["start", "--project-config=bogus.yml"])
+        expect(Kernel).not_to receive(:exec)
+        expect { capture_io { cli.start } }.to raise_error(SystemExit)
       end
 
       it "passes additional arguments through" do


### PR DESCRIPTION
As things stand, project-config will take precedence over a named/traditional project in the case that both are provided.  This could potentially lead to a confusing scenario for end users where someone passes a project-config, project name _and_ additional args: If they were enumerating the args via ERB in their project config file, they'd see an entry for the project name, which would very likely be undesirable. There's no (simple) way of sussing out whether or not they've provided a project name or an optarg, so I think the simplest approach is to pass the name through as an optarg and rely on the note in the README.

Fixes #639.