### PR TITLE
Add support for tmux 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - "2.4.3"
   - "2.5.0"
 env:
+  - TMUX_VERSION=2.8
   - TMUX_VERSION=2.7
   - TMUX_VERSION=2.6
   - TMUX_VERSION=2.5

--- a/lib/tmuxinator.rb
+++ b/lib/tmuxinator.rb
@@ -20,7 +20,8 @@ module Tmuxinator
     2.4,
     2.5,
     2.6,
-    2.7
+    2.7,
+    2.8
   ].freeze
 end
 


### PR DESCRIPTION
This adds tmux 2.8 to the supported matrix and to the travis.yml file.

I did not update the changelog because I wasn't sure of the ticket number that would be created by the PR.