### PR TITLE
Update README to fix custom attach hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ attach: false
 If you want to attach to tmux in a non-standard way (e.g. for a program that makes use of tmux control mode like iTerm2), you can run arbitrary commands by using a project hook:
 
 ```yaml
-on_project_start: tmux -CC attach
+on_project_exit: tmux -CC attach
 ```
 
 ## Passing directly to send-keys


### PR DESCRIPTION
Commit 0fb1a8d0537bce3249edb39678163c78eb6cdc20 adds documentation for custom attach to tmux session using new hook functionality, but referencing the `on_project_start` hook instead of `on_project_exit`. The `on_project_exit` is the right hook to use, as is the proper replacement for the `post` configuration now deprecated.