### PR TITLE
Add quiet flag to prevent tmux version warning (#583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+- Add `--suppress-tmux-version-warning` flag to prevent tmux version warning (#583)
+  - Separate version warning from deprecation messages
+  - Add unsupported version warnings for `stop` and `local` as well
 ### Misc
 - quiet deprecation warnings in test output (#619)
 - reword "Project Configuration Location" section of README to reflect current

--- a/lib/tmuxinator.rb
+++ b/lib/tmuxinator.rb
@@ -7,24 +7,9 @@ require "xdg"
 require "yaml"
 
 module Tmuxinator
-  SUPPORTED_TMUX_VERSIONS = [
-    1.5,
-    1.6,
-    1.7,
-    1.8,
-    1.9,
-    2.0,
-    2.1,
-    2.2,
-    2.3,
-    2.4,
-    2.5,
-    2.6,
-    2.7,
-    2.8
-  ].freeze
 end
 
+require "tmuxinator/tmux_version"
 require "tmuxinator/util"
 require "tmuxinator/deprecations"
 require "tmuxinator/wemux_support"

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -210,6 +210,10 @@ module Tmuxinator
         Kernel.exec(project.render)
       end
 
+      def version_warning?(suppress_flag)
+        !Tmuxinator::TmuxVersion.supported? && !suppress_flag
+      end
+
       def show_version_warning
         say Tmuxinator::TmuxVersion::UNSUPPORTED_VERSION_MSG, :red
         say
@@ -231,6 +235,8 @@ module Tmuxinator
                          desc: "Give the session a different name"
     method_option "project-config", aliases: "-p",
                                     desc: "Path to project config file"
+    method_option "suppress-tmux-version-warning",
+                  desc: "Don't show a warning for unsupported tmux versions"
 
     def start(name = nil, *args)
       # project-config takes precedence over a named project in the case that
@@ -248,7 +254,9 @@ module Tmuxinator
         project_config: options["project-config"]
       }
 
-      show_version_warning unless Tmuxinator::TmuxVersion.supported?
+      show_version_warning if version_warning?(
+        options["suppress-tmux-version-warning"]
+      )
 
       project = create_project(params)
       render_project(project)
@@ -256,13 +264,16 @@ module Tmuxinator
 
     desc "stop [PROJECT]", COMMANDS[:stop]
     map "st" => :stop
+    method_option "suppress-tmux-version-warning",
+                  desc: "Don't show a warning for unsupported tmux versions"
 
     def stop(name)
       params = {
         name: name
       }
-
-      show_version_warning unless Tmuxinator::TmuxVersion.supported?
+      show_version_warning if version_warning?(
+        options["suppress-tmux-version-warning"]
+      )
 
       project = create_project(params)
       kill_project(project)
@@ -270,9 +281,13 @@ module Tmuxinator
 
     desc "local", COMMANDS[:local]
     map "." => :local
+    method_option "suppress-tmux-version-warning",
+                  desc: "Don't show a warning for unsupported tmux versions"
 
     def local
-      show_version_warning unless Tmuxinator::TmuxVersion.supported?
+      show_version_warning if version_warning?(
+        options["suppress-tmux-version-warning"]
+      )
 
       render_project(create_project(attach: options[:attach]))
     end

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -210,6 +210,13 @@ module Tmuxinator
         Kernel.exec(project.render)
       end
 
+      def show_version_warning
+        say Tmuxinator::TmuxVersion::TMUX_MASTER_DEP_MSG, :red
+        say
+        print "Press ENTER to continue."
+        STDIN.getc
+      end
+
       def kill_project(project)
         Kernel.exec(project.kill)
       end
@@ -241,6 +248,7 @@ module Tmuxinator
         project_config: options["project-config"]
       }
 
+      show_version_warning if Tmuxinator::TmuxVersion.unsupported_version?
       project = create_project(params)
       render_project(project)
     end

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -272,6 +272,8 @@ module Tmuxinator
     map "." => :local
 
     def local
+      show_version_warning unless Tmuxinator::TmuxVersion.supported?
+
       render_project(create_project(attach: options[:attach]))
     end
 

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -211,7 +211,7 @@ module Tmuxinator
       end
 
       def show_version_warning
-        say Tmuxinator::TmuxVersion::TMUX_MASTER_DEP_MSG, :red
+        say Tmuxinator::TmuxVersion::UNSUPPORTED_VERSION_MSG, :red
         say
         print "Press ENTER to continue."
         STDIN.getc
@@ -248,7 +248,7 @@ module Tmuxinator
         project_config: options["project-config"]
       }
 
-      show_version_warning if Tmuxinator::TmuxVersion.unsupported_version?
+      show_version_warning unless Tmuxinator::TmuxVersion.supported?
       project = create_project(params)
       render_project(project)
     end

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -202,9 +202,7 @@ module Tmuxinator
       def render_project(project)
         if project.deprecations.any?
           project.deprecations.each { |deprecation| say deprecation, :red }
-          say
-          print "Press ENTER to continue."
-          STDIN.getc
+          show_continuation_prompt
         end
 
         Kernel.exec(project.render)
@@ -216,6 +214,10 @@ module Tmuxinator
 
       def show_version_warning
         say Tmuxinator::TmuxVersion::UNSUPPORTED_VERSION_MSG, :red
+        show_continuation_prompt
+      end
+
+      def show_continuation_prompt
         say
         print "Press ENTER to continue."
         STDIN.getc

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -249,6 +249,7 @@ module Tmuxinator
       }
 
       show_version_warning unless Tmuxinator::TmuxVersion.supported?
+
       project = create_project(params)
       render_project(project)
     end
@@ -260,6 +261,9 @@ module Tmuxinator
       params = {
         name: name
       }
+
+      show_version_warning unless Tmuxinator::TmuxVersion.supported?
+
       project = create_project(params)
       kill_project(project)
     end

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -34,11 +34,6 @@ module Tmuxinator
     DEPRECATION: The `post` option has been replaced by project hooks and will
     not be supported anymore.
     M
-    TMUX_MASTER_DEP_MSG = <<-M
-    DEPRECATION: You are running tmuxinator with an unsupported version of tmux.
-    Please consider using a supported version:
-    (#{Tmuxinator::SUPPORTED_TMUX_VERSIONS.join(', ')})
-    M
 
     attr_reader :yaml
     attr_reader :force_attach
@@ -276,8 +271,7 @@ module Tmuxinator
         cli_args?,
         legacy_synchronize?,
         pre?,
-        post?,
-        unsupported_version?
+        post?
       ]
     end
 
@@ -288,8 +282,7 @@ module Tmuxinator
         CLIARGS_DEP_MSG,
         SYNC_DEP_MSG,
         PRE_DEP_MSG,
-        POST_DEP_MSG,
-        TMUX_MASTER_DEP_MSG
+        POST_DEP_MSG
       ]
     end
 
@@ -319,10 +312,6 @@ module Tmuxinator
 
     def post?
       yaml["post"]
-    end
-
-    def unsupported_version?
-      !Tmuxinator::SUPPORTED_TMUX_VERSIONS.include?(Tmuxinator::Config.version)
     end
 
     def get_pane_base_index

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -1,0 +1,29 @@
+module Tmuxinator
+  module TmuxVersion
+    SUPPORTED_TMUX_VERSIONS = [
+      1.5,
+      1.6,
+      1.7,
+      1.8,
+      1.9,
+      2.0,
+      2.1,
+      2.2,
+      2.3,
+      2.4,
+      2.5,
+      2.6,
+      2.7,
+      2.8
+    ].freeze
+    TMUX_MASTER_DEP_MSG = <<-MSG.freeze
+    DEPRECATION: You are running tmuxinator with an unsupported version of tmux.
+    Please consider using a supported version:
+    (#{Tmuxinator::TmuxVersion::SUPPORTED_TMUX_VERSIONS.join(', ')})
+    MSG
+
+    def self.unsupported_version?
+      !SUPPORTED_TMUX_VERSIONS.include?(Tmuxinator::Config.version)
+    end
+  end
+end

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -17,7 +17,7 @@ module Tmuxinator
       2.8
     ].freeze
     UNSUPPORTED_VERSION_MSG = <<-MSG.freeze
-    DEPRECATION: You are running tmuxinator with an unsupported version of tmux.
+    WARNING: You are running tmuxinator with an unsupported version of tmux.
     Please consider using a supported version:
     (#{SUPPORTED_TMUX_VERSIONS.join(', ')})
     MSG

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -16,14 +16,14 @@ module Tmuxinator
       2.7,
       2.8
     ].freeze
-    TMUX_MASTER_DEP_MSG = <<-MSG.freeze
+    UNSUPPORTED_VERSION_MSG = <<-MSG.freeze
     DEPRECATION: You are running tmuxinator with an unsupported version of tmux.
     Please consider using a supported version:
-    (#{Tmuxinator::TmuxVersion::SUPPORTED_TMUX_VERSIONS.join(', ')})
+    (#{SUPPORTED_TMUX_VERSIONS.join(', ')})
     MSG
 
-    def self.unsupported_version?
-      !SUPPORTED_TMUX_VERSIONS.include?(Tmuxinator::Config.version)
+    def self.supported?(version = Tmuxinator::Config.version)
+      SUPPORTED_TMUX_VERSIONS.include?(version)
     end
   end
 end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -310,13 +310,13 @@ describe Tmuxinator::Cli do
   end
 
   describe "#local" do
-    shared_examples_for :local_project do
-      before do
-        allow(Tmuxinator::Config).to receive_messages(validate: project)
-        allow(Tmuxinator::Config).to receive_messages(version: 1.9)
-        allow(Kernel).to receive(:exec)
-      end
+    before do
+      allow(Tmuxinator::Config).to receive_messages(validate: project)
+      allow(Tmuxinator::Config).to receive_messages(version: 1.9)
+      allow(Kernel).to receive(:exec)
+    end
 
+    shared_examples_for :local_project do
       it "starts the project" do
         expect(Kernel).to receive(:exec)
         out, err = capture_io { cli.start }
@@ -338,6 +338,8 @@ describe Tmuxinator::Cli do
       end
       it_should_behave_like :local_project
     end
+
+    include_examples :unsupported_version_message, :local
   end
 
   describe "#start(custom_name)" do

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -222,6 +222,17 @@ describe Tmuxinator::Cli do
         out, _err = capture_io { cli.start }
         expect(out).to include "WARNING"
       end
+
+      context "with --suppress-tmux-version-warning flag" do
+        before do
+          ARGV.replace([*args, "--suppress-tmux-version-warning"])
+        end
+
+        it "does not print the warning" do
+          out, _err = capture_io { cli.start }
+          expect(out).not_to include "WARNING"
+        end
+      end
     end
 
     context "supported version" do

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -262,9 +262,9 @@ describe Tmuxinator::Cli do
         allow(Tmuxinator::TmuxVersion).to receive(:supported?).and_return(false)
       end
 
-      it "prints the deprecations" do
+      it "prints the warning" do
         out, _err = capture_io { cli.start }
-        expect(out).to include "DEPRECATION"
+        expect(out).to include "WARNING"
       end
     end
   end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -255,6 +255,18 @@ describe Tmuxinator::Cli do
         expect(out).to include "DEPRECATION"
       end
     end
+
+    context "unsupported version" do
+      before do
+        allow($stdin).to receive_messages(getc: "y")
+        allow(Tmuxinator::TmuxVersion).to receive(:supported?).and_return(false)
+      end
+
+      it "prints the deprecations" do
+        out, _err = capture_io { cli.start }
+        expect(out).to include "DEPRECATION"
+      end
+    end
   end
 
   describe "#stop" do

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -207,6 +207,36 @@ describe Tmuxinator::Cli do
     end
   end
 
+  shared_examples_for :unsupported_version_message do |*args|
+    before do
+      ARGV.replace([*args])
+    end
+
+    context "unsupported version" do
+      before do
+        allow($stdin).to receive_messages(getc: "y")
+        allow(Tmuxinator::TmuxVersion).to receive(:supported?).and_return(false)
+      end
+
+      it "prints the warning" do
+        out, _err = capture_io { cli.start }
+        expect(out).to include "WARNING"
+      end
+    end
+
+    context "supported version" do
+      before do
+        allow($stdin).to receive_messages(getc: "y")
+        allow(Tmuxinator::TmuxVersion).to receive(:supported?).and_return(true)
+      end
+
+      it "does not print the warning" do
+        out, _err = capture_io { cli.start }
+        expect(out).not_to include "WARNING"
+      end
+    end
+  end
+
   describe "#start" do
     before do
       ARGV.replace(["start", "foo"])
@@ -256,29 +286,7 @@ describe Tmuxinator::Cli do
       end
     end
 
-    context "unsupported version" do
-      before do
-        allow($stdin).to receive_messages(getc: "y")
-        allow(Tmuxinator::TmuxVersion).to receive(:supported?).and_return(false)
-      end
-
-      it "prints the warning" do
-        out, _err = capture_io { cli.start }
-        expect(out).to include "WARNING"
-      end
-    end
-
-    context "supported version" do
-      before do
-        allow($stdin).to receive_messages(getc: "y")
-        allow(Tmuxinator::TmuxVersion).to receive(:supported?).and_return(true)
-      end
-
-      it "does not print the warning" do
-        out, _err = capture_io { cli.start }
-        expect(out).not_to include "WARNING"
-      end
-    end
+    include_examples :unsupported_version_message, :start, :foo
   end
 
   describe "#stop" do
@@ -297,6 +305,8 @@ describe Tmuxinator::Cli do
         expect(out).to eq ""
       end
     end
+
+    include_examples :unsupported_version_message, :stop, :foo
   end
 
   describe "#local" do

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -267,6 +267,18 @@ describe Tmuxinator::Cli do
         expect(out).to include "WARNING"
       end
     end
+
+    context "supported version" do
+      before do
+        allow($stdin).to receive_messages(getc: "y")
+        allow(Tmuxinator::TmuxVersion).to receive(:supported?).and_return(true)
+      end
+
+      it "does not print the warning" do
+        out, _err = capture_io { cli.start }
+        expect(out).not_to include "WARNING"
+      end
+    end
   end
 
   describe "#stop" do


### PR DESCRIPTION
This adds a `--quiet` flag for the `start`, `stop` and `local` commands, which will prevent the tmux unsupported version warning from being displayed. The short alias `-q` also works.

As mentioned in #583, this is useful for people running the tmux master version. While working on this, I noticed that the `stop` and `local` did not yet include the warning, even though they do interact with tmux. So I took the liberty of adding the warning and flag for those commands as well.

To make this change fairly easy and understandable I did some refactoring and rather small commits. As this is my first PR _ever_, I'd appreciate any and all feedback.