### PR TITLE
Typo on readme about aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - quiet deprecation warnings in test output (#619)
 - reword "Project Configuration Location" section of README to reflect current
 behavior (#621)
+- correct some type on readme about aliases (#660)
 
 ## 0.13.0
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ tmuxinator new [project]
 ```
 
 For editing you can also use `tmuxinator open [project]`. `new` is aliased to
-`o`,`open`, `e`, `edit` and `n`. Please note that dots can't be used in project
+`n`,`open` to `o`, and `edit` to `e`. Please note that dots can't be used in project
 names as tmux uses them internally to delimit between windows and panes.
 Your default editor (`$EDITOR`) is used to open the file.
 If this is a new project you will see this default config:


### PR DESCRIPTION
I think there is a typo on the readme about aliases. The sentence does not make any sense to me.