### PR TITLE
Fix failing spec with custom TMUXINATOR_CONFIG path

### DIFF
--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -9,9 +9,9 @@ module Tmuxinator
     class << self
       # The directory (created if needed) in which to store new projects
       def directory
-        return environment if File.directory?(environment)
-        return xdg if File.directory?(xdg)
-        return home if File.directory?(home)
+        return environment if environment?
+        return xdg if xdg?
+        return home if home?
         # No project directory specified or existant, default to XDG:
         FileUtils::mkdir_p(xdg)
         xdg
@@ -21,11 +21,19 @@ module Tmuxinator
         ENV["HOME"] + "/.tmuxinator"
       end
 
+      def home?
+        File.directory?(home)
+      end
+
       # ~/.config/tmuxinator unless $XDG_CONFIG_HOME has been configured to use
       # a custom value. (e.g. if $XDG_CONFIG_HOME is set to ~/my-config, the
       # return value will be ~/my-config/tmuxinator)
       def xdg
         XDG["CONFIG"].to_s + "/tmuxinator"
+      end
+
+      def xdg?
+        File.directory?(xdg)
       end
 
       # $TMUXINATOR_CONFIG (and create directory) or "".
@@ -34,6 +42,10 @@ module Tmuxinator
         return "" if environment.to_s.empty? # variable is unset (nil) or blank
         FileUtils::mkdir_p(environment) unless File.directory?(environment)
         environment
+      end
+
+      def environment?
+        File.directory?(environment)
       end
 
       def sample
@@ -119,7 +131,7 @@ module Tmuxinator
       # Listed in search order
       # Used by `implode` and `list` commands
       def directories
-        if !environment.nil? && !environment.empty?
+        if environment?
           [environment]
         else
           [xdg, home].select { |d| File.directory? d }

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -24,7 +24,8 @@ describe Tmuxinator::Cli do
     end
   end
 
-  let(:cli) { Tmuxinator::Cli }
+  subject(:cli) { described_class }
+
   let(:fixtures_dir) { File.expand_path("../../../fixtures/", __FILE__) }
   let(:project) { FactoryBot.build(:project) }
   let(:project_config) do
@@ -421,7 +422,7 @@ describe Tmuxinator::Cli do
         expect(File).not_to exist(path)
 
         # now generate a project file
-        expect(Tmuxinator::Cli.new.generate_project_file(name, path)).to eq path
+        expect(described_class.new.generate_project_file(name, path)).to eq path
         expect(File).to exist path
 
         # add some content to the project file
@@ -829,7 +830,7 @@ describe Tmuxinator::Cli do
       end
 
       it "should generate a project file" do
-        new_path = Tmuxinator::Cli.new.find_project_file(name, false)
+        new_path = described_class.new.find_project_file(name, false)
         expect(new_path).to eq path
         expect(File).to exist new_path
       end
@@ -840,7 +841,7 @@ describe Tmuxinator::Cli do
 
       before do
         expect(File).not_to exist(path), "expected file at #{path} not to exist"
-        expect(Tmuxinator::Cli.new.generate_project_file(name, path)).to eq path
+        expect(described_class.new.generate_project_file(name, path)).to eq path
         expect(File).to exist path
 
         File.open(path, "w") do |f|
@@ -851,7 +852,7 @@ describe Tmuxinator::Cli do
       end
 
       it "should _not_ generate a new project file" do
-        new_path = Tmuxinator::Cli.new.find_project_file(name, false)
+        new_path = described_class.new.find_project_file(name, false)
         expect(new_path).to eq path
         expect(File).to exist new_path
         expect(File.read(new_path)).to match %r{#{extra}}
@@ -866,7 +867,7 @@ describe Tmuxinator::Cli do
       Dir.mktmpdir do |dir|
         path = "#{dir}/#{name}.yml"
         expect(File).not_to exist(path), "expected file at #{path} not to exist"
-        new_path = Tmuxinator::Cli.new.generate_project_file(name, path)
+        new_path = described_class.new.generate_project_file(name, path)
         expect(new_path).to eq path
         expect(File).to exist new_path
       end
@@ -877,7 +878,7 @@ describe Tmuxinator::Cli do
       allow(File).to receive(:open) { |&block| block.yield file }
       Dir.mktmpdir do |dir|
         path = "#{dir}/#{name}.yml"
-        _ = Tmuxinator::Cli.new.generate_project_file(name, path)
+        _ = described_class.new.generate_project_file(name, path)
         expect(file.string).to match %r{\A# #{path}$}
       end
     end
@@ -915,18 +916,18 @@ describe Tmuxinator::Cli do
     context "attach option" do
       describe "detach" do
         it "sets force_detach to false when no attach argument is provided" do
-          project = Tmuxinator::Cli.new.create_project(name: name)
+          project = described_class.new.create_project(name: name)
           expect(project.force_detach).to eq(false)
         end
 
         it "sets force_detach to true when 'attach: false' is provided" do
-          project = Tmuxinator::Cli.new.create_project(attach: false,
+          project = described_class.new.create_project(attach: false,
                                                        name: name)
           expect(project.force_detach).to eq(true)
         end
 
         it "sets force_detach to false when 'attach: true' is provided" do
-          project = Tmuxinator::Cli.new.create_project(attach: true,
+          project = described_class.new.create_project(attach: true,
                                                        name: name)
           expect(project.force_detach).to eq(false)
         end
@@ -934,18 +935,18 @@ describe Tmuxinator::Cli do
 
       describe "attach" do
         it "sets force_attach to false when no attach argument is provided" do
-          project = Tmuxinator::Cli.new.create_project(name: name)
+          project = described_class.new.create_project(name: name)
           expect(project.force_attach).to eq(false)
         end
 
         it "sets force_attach to true when 'attach: true' is provided" do
-          project = Tmuxinator::Cli.new.create_project(attach: true,
+          project = described_class.new.create_project(attach: true,
                                                        name: name)
           expect(project.force_attach).to eq(true)
         end
 
         it "sets force_attach to false when 'attach: false' is provided" do
-          project = Tmuxinator::Cli.new.create_project(attach: false,
+          project = described_class.new.create_project(attach: false,
                                                        name: name)
           expect(project.force_attach).to eq(false)
         end

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -11,7 +11,7 @@ describe Tmuxinator::Config do
         allow(ENV).to receive(:[]).with("TMUXINATOR_CONFIG").
           and_return "expected"
         allow(File).to receive(:directory?).and_return true
-        expect(Tmuxinator::Config.directory).to eq "expected"
+        expect(described_class.directory).to eq "expected"
       end
     end
 
@@ -21,7 +21,7 @@ describe Tmuxinator::Config do
         allow(described_class).to receive(:xdg?).and_return false
         allow(described_class).to receive(:home?).and_return true
 
-        expect(Tmuxinator::Config.directory).to eq Tmuxinator::Config.home
+        expect(described_class.directory).to eq described_class.home
       end
     end
 
@@ -31,7 +31,7 @@ describe Tmuxinator::Config do
         allow(described_class).to receive(:xdg?).and_return true
         allow(described_class).to receive(:home?).and_return false
 
-        expect(Tmuxinator::Config.directory).to eq Tmuxinator::Config.xdg
+        expect(described_class.directory).to eq described_class.xdg
       end
     end
 
@@ -41,7 +41,7 @@ describe Tmuxinator::Config do
         allow(described_class).to receive(:xdg?).and_return true
         allow(described_class).to receive(:home?).and_return true
 
-        expect(Tmuxinator::Config.directory).to eq Tmuxinator::Config.xdg
+        expect(described_class.directory).to eq described_class.xdg
       end
     end
 
@@ -54,7 +54,7 @@ describe Tmuxinator::Config do
         Dir.mktmpdir do |dir|
           config_parent = "#{dir}/non_existant_parent/s"
           allow(XDG).to receive(:[]).with("CONFIG").and_return config_parent
-          expect(Tmuxinator::Config.directory).
+          expect(described_class.directory).
             to eq "#{config_parent}/tmuxinator"
           expect(File.directory?("#{config_parent}/tmuxinator")).to be true
         end
@@ -69,7 +69,7 @@ describe Tmuxinator::Config do
           and_return "expected"
         # allow(XDG).to receive(:[]).with("CONFIG").and_return "expected"
         allow(File).to receive(:directory?).and_return true
-        expect(Tmuxinator::Config.environment).to eq "expected"
+        expect(described_class.environment).to eq "expected"
       end
     end
 
@@ -79,7 +79,7 @@ describe Tmuxinator::Config do
           and_return nil
         # allow(XDG).to receive(:[]).with("CONFIG").and_return nil
         allow(File).to receive(:directory?).and_return true
-        expect(Tmuxinator::Config.environment).to eq ""
+        expect(described_class.environment).to eq ""
       end
     end
 
@@ -87,7 +87,7 @@ describe Tmuxinator::Config do
       it "is an empty string" do
         allow(XDG).to receive(:[]).with("CONFIG").and_return ""
         allow(ENV).to receive(:[]).with("TMUXINATOR_CONFIG").and_return ""
-        expect(Tmuxinator::Config.environment).to eq ""
+        expect(described_class.environment).to eq ""
       end
     end
   end
@@ -100,7 +100,7 @@ describe Tmuxinator::Config do
 
       it "is empty if no configuration directories exist" do
         allow(File).to receive(:directory?).and_return false
-        expect(Tmuxinator::Config.directories).to eq []
+        expect(described_class.directories).to eq []
       end
 
       it "contains #xdg before #home" do
@@ -108,7 +108,7 @@ describe Tmuxinator::Config do
         allow(described_class).to receive(:home).and_return "HOME"
         allow(File).to receive(:directory?).and_return true
 
-        expect(Tmuxinator::Config.directories).to eq \
+        expect(described_class.directories).to eq \
           ["XDG", "HOME"]
       end
     end
@@ -121,37 +121,37 @@ describe Tmuxinator::Config do
       it "is only [$TMUXINATOR_CONFIG] if set" do
         allow(File).to receive(:directory?).and_return true
 
-        expect(Tmuxinator::Config.directories).to eq ["TMUXINATOR_CONFIG"]
+        expect(described_class.directories).to eq ["TMUXINATOR_CONFIG"]
       end
     end
   end
 
   describe "#home" do
     it "is ~/.tmuxinator" do
-      expect(Tmuxinator::Config.home).to eq "#{ENV['HOME']}/.tmuxinator"
+      expect(described_class.home).to eq "#{ENV['HOME']}/.tmuxinator"
     end
   end
 
   describe "#xdg" do
     it "is $XDG_CONFIG_HOME/tmuxinator" do
-      expect(Tmuxinator::Config.xdg).to eq "#{XDG['CONFIG_HOME']}/tmuxinator"
+      expect(described_class.xdg).to eq "#{XDG['CONFIG_HOME']}/tmuxinator"
     end
   end
 
   describe "#sample" do
     it "gets the path of the sample project" do
-      expect(Tmuxinator::Config.sample).to include("sample.yml")
+      expect(described_class.sample).to include("sample.yml")
     end
   end
 
   describe "#default" do
     it "gets the path of the default config" do
-      expect(Tmuxinator::Config.default).to include("default.yml")
+      expect(described_class.default).to include("default.yml")
     end
   end
 
   describe "#version" do
-    subject { Tmuxinator::Config.version }
+    subject { described_class.version }
 
     before do
       expect(Tmuxinator::Doctor).to receive(:installed?).and_return(true)
@@ -173,29 +173,29 @@ describe Tmuxinator::Config do
   describe "#default_path_option" do
     context ">= 1.8" do
       before do
-        allow(Tmuxinator::Config).to receive(:version).and_return(1.8)
+        allow(described_class).to receive(:version).and_return(1.8)
       end
 
       it "returns -c" do
-        expect(Tmuxinator::Config.default_path_option).to eq "-c"
+        expect(described_class.default_path_option).to eq "-c"
       end
     end
 
     context "< 1.8" do
       before do
-        allow(Tmuxinator::Config).to receive(:version).and_return(1.7)
+        allow(described_class).to receive(:version).and_return(1.7)
       end
 
       it "returns default-path" do
-        expect(Tmuxinator::Config.default_path_option).to eq "default-path"
+        expect(described_class.default_path_option).to eq "default-path"
       end
     end
   end
 
   describe "#default?" do
-    let(:directory) { Tmuxinator::Config.directory }
-    let(:local_default) { Tmuxinator::Config::LOCAL_DEFAULT }
-    let(:proj_default) { Tmuxinator::Config.default }
+    let(:directory) { described_class.directory }
+    let(:local_default) { described_class::LOCAL_DEFAULT }
+    let(:proj_default) { described_class.default }
 
     context "when the file exists" do
       before do
@@ -204,7 +204,7 @@ describe Tmuxinator::Config do
       end
 
       it "returns true" do
-        expect(Tmuxinator::Config.default?).to be_truthy
+        expect(described_class.default?).to be_truthy
       end
     end
 
@@ -215,57 +215,57 @@ describe Tmuxinator::Config do
       end
 
       it "returns true" do
-        expect(Tmuxinator::Config.default?).to be_falsey
+        expect(described_class.default?).to be_falsey
       end
     end
   end
 
   describe "#configs" do
     before do
-      allow(Tmuxinator::Config).to receive_messages(xdg: xdg_config_dir)
-      allow(Tmuxinator::Config).to receive_messages(home: home_config_dir)
+      allow(described_class).to receive_messages(xdg: xdg_config_dir)
+      allow(described_class).to receive_messages(home: home_config_dir)
     end
 
     it "gets a sorted list of all projects" do
       allow(described_class).to receive(:environment?).and_return false
 
-      expect(Tmuxinator::Config.configs).
+      expect(described_class.configs).
         to eq ["both", "both", "dup/local-dup", "home", "local-dup", "xdg"]
     end
 
     it "lists only projects in $TMUXINATOR_CONFIG when set" do
       allow(ENV).to receive(:[]).with("TMUXINATOR_CONFIG").
         and_return "#{fixtures_dir}/TMUXINATOR_CONFIG"
-      expect(Tmuxinator::Config.configs).to eq ["TMUXINATOR_CONFIG"]
+      expect(described_class.configs).to eq ["TMUXINATOR_CONFIG"]
     end
   end
 
   describe "#exists?" do
     before do
       allow(File).to receive_messages(exist?: true)
-      allow(Tmuxinator::Config).to receive_messages(project: "")
+      allow(described_class).to receive_messages(project: "")
     end
 
     it "checks if the given project exists" do
-      expect(Tmuxinator::Config.exists?(name: "test")).to be_truthy
+      expect(described_class.exists?(name: "test")).to be_truthy
     end
   end
 
   describe "#global_project" do
-    let(:directory) { Tmuxinator::Config.directory }
+    let(:directory) { described_class.directory }
     let(:base) { "#{directory}/sample.yml" }
     let(:first_dup) { "#{home_config_dir}/dup/local-dup.yml" }
     let(:yaml) { "#{directory}/yaml.yaml" }
 
     before do
-      allow(Tmuxinator::Config).to receive_messages(xdg: fixtures_dir)
-      allow(Tmuxinator::Config).to receive_messages(home: fixtures_dir)
       allow(described_class).to receive(:environment?).and_return false
+      allow(described_class).to receive(:xdg).and_return fixtures_dir
+      allow(described_class).to receive(:home).and_return fixtures_dir
     end
 
     context "with project yml" do
       it "gets the project as path to the yml file" do
-        expect(Tmuxinator::Config.global_project("sample")).to eq base
+        expect(described_class.global_project("sample")).to eq base
       end
     end
 
@@ -277,53 +277,53 @@ describe Tmuxinator::Config do
 
     context "without project yml" do
       it "gets the project as path to the yml file" do
-        expect(Tmuxinator::Config.global_project("new-project")).to be_nil
+        expect(described_class.global_project("new-project")).to be_nil
       end
     end
 
     context "with duplicate project files" do
       it "is the first .yml file found" do
-        expect(Tmuxinator::Config.global_project("local-dup")).to eq first_dup
+        expect(described_class.global_project("local-dup")).to eq first_dup
       end
     end
   end
 
   describe "#local?" do
     it "checks if the given project exists" do
-      path = Tmuxinator::Config::LOCAL_DEFAULT
+      path = described_class::LOCAL_DEFAULT
       expect(File).to receive(:exist?).with(path) { true }
-      expect(Tmuxinator::Config.local?).to be_truthy
+      expect(described_class.local?).to be_truthy
     end
   end
 
   describe "#local_project" do
-    let(:default) { Tmuxinator::Config::LOCAL_DEFAULT }
+    let(:default) { described_class::LOCAL_DEFAULT }
 
     context "with a project yml" do
       it "gets the project as path to the yml file" do
         expect(File).to receive(:exist?).with(default) { true }
-        expect(Tmuxinator::Config.local_project).to eq default
+        expect(described_class.local_project).to eq default
       end
     end
 
     context "without project yml" do
       it "gets the project as path to the yml file" do
-        expect(Tmuxinator::Config.local_project).to be_nil
+        expect(described_class.local_project).to be_nil
       end
     end
   end
 
   describe "#project" do
-    let(:directory) { Tmuxinator::Config.directory }
-    let(:default) { Tmuxinator::Config::LOCAL_DEFAULT }
+    let(:directory) { described_class.directory }
+    let(:default) { described_class::LOCAL_DEFAULT }
 
     context "with an non-local project yml" do
       before do
-        allow(Tmuxinator::Config).to receive_messages(directory: fixtures_dir)
+        allow(described_class).to receive_messages(directory: fixtures_dir)
       end
 
       it "gets the project as path to the yml file" do
-        expect(Tmuxinator::Config.project("sample")).
+        expect(described_class.project("sample")).
           to eq "#{directory}/sample.yml"
       end
     end
@@ -331,48 +331,48 @@ describe Tmuxinator::Config do
     context "with a local project, but no global project" do
       it "gets the project as path to the yml file" do
         expect(File).to receive(:exist?).with(default) { true }
-        expect(Tmuxinator::Config.project("sample")).to eq "./.tmuxinator.yml"
+        expect(described_class.project("sample")).to eq "./.tmuxinator.yml"
       end
     end
 
     context "without project yml" do
       let(:expected) { "#{directory}/new-project.yml" }
       it "gets the project as path to the yml file" do
-        expect(Tmuxinator::Config.project("new-project")).to eq expected
+        expect(described_class.project("new-project")).to eq expected
       end
     end
   end
 
   describe "#validate" do
-    let(:default) { Tmuxinator::Config::LOCAL_DEFAULT }
+    let(:default) { described_class::LOCAL_DEFAULT }
 
     context "when a project config file is provided" do
       it "should raise if the project config file can't be found" do
         project_config = "dont-exist.yml"
         regex = /Project config \(#{project_config}\) doesn't exist\./
         expect do
-          Tmuxinator::Config.validate(project_config: project_config)
+          described_class.validate(project_config: project_config)
         end.to raise_error RuntimeError, regex
       end
 
       it "should load and validate the project" do
         project_config = File.join(fixtures_dir, "sample.yml")
-        expect(Tmuxinator::Config.validate(project_config: project_config)).to \
+        expect(described_class.validate(project_config: project_config)).to \
           be_a Tmuxinator::Project
       end
 
       it "should take precedence over a named project" do
-        allow(Tmuxinator::Config).to receive_messages(directory: fixtures_dir)
+        allow(described_class).to receive_messages(directory: fixtures_dir)
         project_config = File.join(fixtures_dir, "sample_number_as_name.yml")
-        project = Tmuxinator::Config.validate(name: "sample",
-                                              project_config: project_config)
+        project = described_class.validate(name: "sample",
+                                           project_config: project_config)
         expect(project.name).to eq("222")
       end
 
       it "should take precedence over a local project" do
-        expect(Tmuxinator::Config).not_to receive(:local?)
+        expect(described_class).not_to receive(:local?)
         project_config = File.join(fixtures_dir, "sample_number_as_name.yml")
-        project = Tmuxinator::Config.validate(project_config: project_config)
+        project = described_class.validate(project_config: project_config)
         expect(project.name).to eq("222")
       end
     end
@@ -380,13 +380,13 @@ describe Tmuxinator::Config do
     context "when a project name is provided" do
       it "should raise if the project file can't be found" do
         expect do
-          Tmuxinator::Config.validate(name: "sample")
+          described_class.validate(name: "sample")
         end.to raise_error RuntimeError, %r{Project.+doesn't.exist}
       end
 
       it "should load and validate the project" do
-        expect(Tmuxinator::Config).to receive_messages(directory: fixtures_dir)
-        expect(Tmuxinator::Config.validate(name: "sample")).to \
+        expect(described_class).to receive_messages(directory: fixtures_dir)
+        expect(described_class.validate(name: "sample")).to \
           be_a Tmuxinator::Project
       end
     end
@@ -395,7 +395,7 @@ describe Tmuxinator::Config do
       it "should raise if the local project file doesn't exist" do
         expect(File).to receive(:exist?).with(default) { false }
         expect do
-          Tmuxinator::Config.validate
+          described_class.validate
         end.to raise_error RuntimeError, %r{Project.+doesn't.exist}
       end
 
@@ -405,18 +405,19 @@ describe Tmuxinator::Config do
         expect(File).to receive(:exist?).with(default).at_least(:once) { true }
         expect(File).to receive(:read).with(default).and_return(content)
 
-        expect(Tmuxinator::Config.validate).to be_a Tmuxinator::Project
+        expect(described_class.validate).to be_a Tmuxinator::Project
       end
     end
 
     context "when no project can be found" do
       it "should raise with NO_PROJECT_FOUND_MSG" do
-        config = Tmuxinator::Config
-        expect(config).to receive(:valid_project_config?).and_return(false)
-        expect(config).to receive(:valid_local_project?).and_return(false)
-        expect(config).to receive(:valid_standard_project?).and_return(false)
+        expect(described_class).to receive_messages(
+          valid_project_config?: false,
+          valid_local_project?: false,
+          valid_standard_project?: false
+        )
         expect do
-          Tmuxinator::Config.validate
+          described_class.validate
         end.to raise_error RuntimeError, %r{Project could not be found\.}
       end
     end

--- a/spec/lib/tmuxinator/doctor_spec.rb
+++ b/spec/lib/tmuxinator/doctor_spec.rb
@@ -8,7 +8,7 @@ describe Tmuxinator::Doctor do
       end
 
       it "returns true" do
-        expect(Tmuxinator::Doctor.installed?).to be_truthy
+        expect(described_class.installed?).to be_truthy
       end
     end
 
@@ -18,7 +18,7 @@ describe Tmuxinator::Doctor do
       end
 
       it "returns false" do
-        expect(Tmuxinator::Doctor.installed?).to be_falsey
+        expect(described_class.installed?).to be_falsey
       end
     end
   end
@@ -30,7 +30,7 @@ describe Tmuxinator::Doctor do
       end
 
       it "returns true" do
-        expect(Tmuxinator::Doctor.editor?).to be_truthy
+        expect(described_class.editor?).to be_truthy
       end
     end
 
@@ -40,7 +40,7 @@ describe Tmuxinator::Doctor do
       end
 
       it "returns false" do
-        expect(Tmuxinator::Doctor.editor?).to be_falsey
+        expect(described_class.editor?).to be_falsey
       end
     end
   end
@@ -52,7 +52,7 @@ describe Tmuxinator::Doctor do
       end
 
       it "returns true" do
-        expect(Tmuxinator::Doctor.shell?).to be_truthy
+        expect(described_class.shell?).to be_truthy
       end
     end
 
@@ -62,7 +62,7 @@ describe Tmuxinator::Doctor do
       end
 
       it "returns false" do
-        expect(Tmuxinator::Doctor.shell?).to be_falsey
+        expect(described_class.shell?).to be_falsey
       end
     end
   end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -33,12 +33,12 @@ describe Tmuxinator::Window do
     }
   end
 
-  let(:window) { Tmuxinator::Window.new(yaml, 0, project) }
-  let(:window_root) { Tmuxinator::Window.new(yaml_root, 0, project) }
+  let(:window) { described_class.new(yaml, 0, project) }
+  let(:window_root) { described_class.new(yaml_root, 0, project) }
 
   shared_context "window command context" do
     let(:project) { double(:project) }
-    let(:window) { Tmuxinator::Window.new(yaml, 0, project) }
+    let(:window) { described_class.new(yaml, 0, project) }
     let(:root?) { true }
     let(:root) { "/project/tmuxinator" }
 


### PR DESCRIPTION
 Fix failing tests when TMUXINATOR_CONFIG is set

When the environment variable TMUXINATOR_CONFIG is set to a custom path,
the specs would fail*. This fixes #665 by putting a bandaid on the affected test.

I call it a bandaid because I am still not happy with the tests. Mostly because there is stubbing at many different levels:

- Entire methods
- Parts of methods, especially File.directory?
- Env variables

Stubbing ENV is not ideal, see for example
https://robots.thoughtbot.com/testing-and-environment-variables
But in this case, I get the feeling that setting up a cleanly stubbed
ENV would replace most of the other stubbing while being easier to
understand. This may be an idea for the future.

*Reproduce with:
TMUXINATOR_CONFIG=$(pwd)/spec/fixtures/dot-tmuxinator bundle exec rspec spec