### PR TITLE
Add support list --newline (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## UNRELEASED
+- Add `-n, [--newline], [--no-newline]` flag for list command
+    Force output to be one entry per line 
 ### Misc
 - make pre/post deprecation warnings more descriptive
 - remove pre/post from project configuration template

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -31,7 +31,7 @@ module Tmuxinator
       implode: "Deletes all tmuxinator projects",
       version: "Display installed tmuxinator version",
       doctor: "Look for problems in your configuration",
-      list: "Lists all tmuxinator projects"
+      list: "Lists all tmuxinator projects",
     }.freeze
 
     # For future reference: due to how tmuxinator currently consumes
@@ -378,11 +378,17 @@ module Tmuxinator
     desc "list", COMMANDS[:list]
     map "l" => :list
     map "ls" => :list
+    method_option :newline, type: :boolean,
+                            aliases: ["-n"],
+                            desc: "Force output to be one entry per line."
 
     def list
       say "tmuxinator projects:"
-
-      print_in_columns Tmuxinator::Config.configs
+      if options[:newline]
+        say Tmuxinator::Config.configs.join("\n")
+      else
+        print_in_columns Tmuxinator::Config.configs
+      end
     end
 
     desc "version", COMMANDS[:version]

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -31,7 +31,7 @@ module Tmuxinator
       implode: "Deletes all tmuxinator projects",
       version: "Display installed tmuxinator version",
       doctor: "Look for problems in your configuration",
-      list: "Lists all tmuxinator projects",
+      list: "Lists all tmuxinator projects"
     }.freeze
 
     # For future reference: due to how tmuxinator currently consumes

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -783,12 +783,23 @@ describe Tmuxinator::Cli do
 
   describe "#list" do
     before do
-      ARGV.replace(["list"])
       allow(Dir).to receive_messages(:[] => ["/path/to/project.yml"])
     end
 
-    it "lists all projects" do
-      expect { capture_io { cli.start } }.to_not raise_error
+    context "set --newline flag " do
+      ARGV.replace(["list --newline"])
+
+      it "force output to be one entry per line" do
+        expect { capture_io { cli.start } }.to_not raise_error
+      end
+    end
+
+    context "no arguments are given" do
+      ARGV.replace(["list"])
+
+      it "lists all projects " do
+        expect { capture_io { cli.start } }.to_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
 Add support list --newline (#678)

created a --newline flag for the ``list`` command. Read up on issue #678 [here](https://github.com/tmuxinator/tmuxinator/issues/678)
```bash
-n, [--newline], [--no-newline]  # Force output to be one entry per line
```

Small sidenote:
this is my first public MRQ and ruby contribution, any feedback is welcome