### PR TITLE
Move project load out of config validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Misc
+Small refactor to move Config.version to TmuxVersion.version
+
+
 ## 0.16.0
 ### Bugfixes
 - fix wemux class_eval error (#590)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Misc
 Small refactor to move Config.version to TmuxVersion.version
+Small refactor to move asset_path methods out of Config and into their own AssetPath class
 
 
 ## 0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Misc
 Small refactor to move Config.version to TmuxVersion.version
 Small refactor to move asset_path methods out of Config and into their own AssetPath class
+Isolate finding a config file from the parsing of the file
 
 
 ## 0.16.0

--- a/lib/tmuxinator.rb
+++ b/lib/tmuxinator.rb
@@ -12,6 +12,7 @@ end
 require "tmuxinator/tmux_version"
 require "tmuxinator/util"
 require "tmuxinator/deprecations"
+require "tmuxinator/asset_path"
 require "tmuxinator/wemux_support"
 require "tmuxinator/cli"
 require "tmuxinator/config"

--- a/lib/tmuxinator/asset_path.rb
+++ b/lib/tmuxinator/asset_path.rb
@@ -1,0 +1,27 @@
+module Tmuxinator
+  class AssetPath
+    class << self
+      def sample
+        asset_path "sample.yml"
+      end
+
+      def template
+        asset_path "template.erb"
+      end
+
+      def stop_template
+        asset_path "template-stop.erb"
+      end
+
+      def wemux_template
+        asset_path "wemux_template.erb"
+      end
+
+      private
+
+      def asset_path(asset)
+        "#{File.dirname(__FILE__)}/assets/#{asset}"
+      end
+    end
+  end
+end

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -26,7 +26,7 @@ cd <%= root || "." %>
   <%= windows.first.tmux_window_command_prefix %> <%= "cd #{windows.first.root}".shellescape %> C-m
   <% end %>
 
-  <% if Tmuxinator::Config.version < 1.7 %>
+  <% if Tmuxinator::TmuxVersion.version < 1.7 %>
   # Set the default path for versions prior to 1.7
     <% if root? %>
   <%= tmux %> set-option -t <%= name %> <%= Tmuxinator::Config.default_path_option %> <%= root -%> 1>/dev/null

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -197,7 +197,8 @@ module Tmuxinator
         }
 
         begin
-          Tmuxinator::Config.validate(options)
+          project_file_path = Tmuxinator::Config.validate(options)
+          Tmuxinator::Project.load(project_file_path, options).validate!
         rescue => e
           exit! e.message
         end

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -167,9 +167,13 @@ module Tmuxinator
       end
 
       def generate_project_file(name, path)
-        template = Tmuxinator::Config.default? ? :default : :sample
-        content = File.read(Tmuxinator::Config.send(template.to_sym))
-        erb = Erubis::Eruby.new(content).result(binding)
+        template_path = if Tmuxinator::Config.default?
+                          Tmuxinator::Config.default
+                        else
+                          Tmuxinator::AssetPath.sample
+                        end
+        template_content = File.read(template_path)
+        erb = Erubis::Eruby.new(template_content).result(binding)
         File.open(path, "w") { |f| f.write(erb) }
         path
       end

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -96,7 +96,7 @@ module Tmuxinator
       end
 
       def new_project_with_session(name, session)
-        if Tmuxinator::Config.version < 1.6
+        if Tmuxinator::TmuxVersion.version < 1.6
           raise "Creating projects from sessions is unsupported\
             for tmux version 1.5 or lower."
         end

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -47,10 +47,6 @@ module Tmuxinator
         File.directory?(environment)
       end
 
-      def sample
-        asset_path "sample.yml"
-      end
-
       def default
         "#{directory}/default.yml"
       end
@@ -91,18 +87,6 @@ module Tmuxinator
       # Pathname of the given project
       def project(name)
         global_project(name) || local_project || default_project(name)
-      end
-
-      def template
-        asset_path "template.erb"
-      end
-
-      def stop_template
-        asset_path "template-stop.erb"
-      end
-
-      def wemux_template
-        asset_path "wemux_template.erb"
       end
 
       # Sorted list of all .yml files, including duplicates
@@ -171,10 +155,6 @@ module Tmuxinator
       alias :project_in_local :local_project
 
       private
-
-      def asset_path(asset)
-        "#{File.dirname(__FILE__)}/assets/#{asset}"
-      end
 
       # The first pathname of the project named 'name' found while
       # recursively searching 'directory'

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -131,10 +131,8 @@ module Tmuxinator
 
       def validate(options = {})
         name = options[:name]
-        options[:force_attach] ||= false
-        options[:force_detach] ||= false
         project_config = options.fetch(:project_config) { false }
-        project_file = if valid_project_config?(project_config)
+        project_file_path = if valid_project_config?(project_config)
                          project_config
                        elsif valid_local_project?(name)
                          local_project
@@ -145,8 +143,7 @@ module Tmuxinator
                          # but just in case ...
                          raise NO_PROJECT_FOUND_MSG
                        end
-
-        Tmuxinator::Project.load(project_file, options).validate!
+        project_file_path
       end
 
       # Deprecated methods: ignore the 1st, use the 2nd

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -4,7 +4,6 @@ module Tmuxinator
     NO_LOCAL_FILE_MSG =
       "Project file at ./.tmuxinator.yml doesn't exist.".freeze
     NO_PROJECT_FOUND_MSG = "Project could not be found.".freeze
-    TMUX_MASTER_VERSION = Float::INFINITY
 
     class << self
       # The directory (created if needed) in which to store new projects
@@ -60,20 +59,8 @@ module Tmuxinator
         exists?(name: "default")
       end
 
-      def version
-        if Tmuxinator::Doctor.installed?
-          tmux_version = `tmux -V`.split(" ")[1]
-
-          if tmux_version == "master"
-            TMUX_MASTER_VERSION
-          else
-            tmux_version.to_f
-          end
-        end
-      end
-
       def default_path_option
-        version && version < 1.8 ? "default-path" : "-c"
+        TmuxVersion.version && TmuxVersion.version < 1.8 ? "default-path" : "-c"
       end
 
       def exists?(name: nil, path: nil)

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -94,11 +94,11 @@ module Tmuxinator
     end
 
     def render
-      self.class.render_template(Tmuxinator::Config.template, binding)
+      self.class.render_template(Tmuxinator::AssetPath.template, binding)
     end
 
     def kill
-      self.class.render_template(Tmuxinator::Config.stop_template, binding)
+      self.class.render_template(Tmuxinator::AssetPath.stop_template, binding)
     end
 
     def self.render_template(template, bndg)

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -40,6 +40,10 @@ module Tmuxinator
     attr_reader :custom_name
 
     def self.load(path, options = {})
+      # I'm refactoring some things so I'm just sticking this here for now
+      options[:force_attach] ||= false
+      options[:force_detach] ||= false
+
       yaml = begin
         raw_content = File.read(path)
 

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -1,5 +1,7 @@
 module Tmuxinator
   module TmuxVersion
+    TMUX_MASTER_VERSION = Float::INFINITY
+
     SUPPORTED_TMUX_VERSIONS = [
       1.5,
       1.6,
@@ -22,8 +24,20 @@ module Tmuxinator
     (#{SUPPORTED_TMUX_VERSIONS.join(', ')})
     MSG
 
-    def self.supported?(version = Tmuxinator::Config.version)
+    def self.supported?(version = Tmuxinator::TmuxVersion.version)
       SUPPORTED_TMUX_VERSIONS.include?(version)
+    end
+
+    def self.version
+      if Tmuxinator::Doctor.installed?
+        tmux_version = `tmux -V`.split(" ")[1]
+
+        if tmux_version == "master"
+          TMUX_MASTER_VERSION
+        else
+          tmux_version.to_f
+        end
+      end
     end
   end
 end

--- a/lib/tmuxinator/wemux_support.rb
+++ b/lib/tmuxinator/wemux_support.rb
@@ -2,7 +2,7 @@ module Tmuxinator
   module WemuxSupport
     def render
       Tmuxinator::Project.render_template(
-        Tmuxinator::Config.wemux_template,
+        Tmuxinator::AssetPath.wemux_template,
         binding
       )
     end

--- a/spec/lib/tmuxinator/asset_path_spec.rb
+++ b/spec/lib/tmuxinator/asset_path_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe Tmuxinator::AssetPath do
+  describe "#sample" do
+    it "gets the path of the sample project" do
+      expect(described_class.sample).to include("sample.yml")
+    end
+  end
+  describe "#template" do
+    it "gets the path of the project template" do
+      expect(described_class.template).to include("template.erb")
+    end
+  end
+  describe "#stop_template" do
+    it "gets the path of the stop_template template" do
+      expect(described_class.stop_template).to include("template-stop.erb")
+    end
+  end
+  describe "#wemux_template" do
+    it "gets the path of the wemux_template template" do
+      expect(described_class.wemux_template).to include("wemux_template.erb")
+    end
+  end
+end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -252,8 +252,8 @@ describe Tmuxinator::Cli do
   describe "#start" do
     before do
       ARGV.replace(["start", "foo"])
+      stub_tmux_version(1.9)
       allow(Tmuxinator::Config).to receive_messages(validate: project)
-      allow(Tmuxinator::Config).to receive_messages(version: 1.9)
       allow(Kernel).to receive(:exec)
     end
 
@@ -304,8 +304,8 @@ describe Tmuxinator::Cli do
   describe "#stop" do
     before do
       ARGV.replace(["stop", "foo"])
+      stub_tmux_version(1.9)
       allow(Tmuxinator::Config).to receive_messages(validate: project)
-      allow(Tmuxinator::Config).to receive_messages(version: 1.9)
       allow(Kernel).to receive(:exec)
     end
 
@@ -323,8 +323,8 @@ describe Tmuxinator::Cli do
 
   describe "#local" do
     before do
+      stub_tmux_version(1.9)
       allow(Tmuxinator::Config).to receive_messages(validate: project)
-      allow(Tmuxinator::Config).to receive_messages(version: 1.9)
       allow(Kernel).to receive(:exec)
     end
 
@@ -357,8 +357,8 @@ describe Tmuxinator::Cli do
   describe "#start(custom_name)" do
     before do
       ARGV.replace(["start", "foo", "bar"])
+      stub_tmux_version(1.9)
       allow(Tmuxinator::Config).to receive_messages(validate: project)
-      allow(Tmuxinator::Config).to receive_messages(version: 1.9)
       allow(Kernel).to receive(:exec)
     end
 
@@ -372,8 +372,8 @@ describe Tmuxinator::Cli do
 
   describe "#start(with project config file)" do
     before do
+      stub_tmux_version(1.9)
       allow(Tmuxinator::Config).to receive(:validate).and_call_original
-      allow(Tmuxinator::Config).to receive_messages(version: 1.9)
       allow(Kernel).to receive(:exec)
     end
 
@@ -515,7 +515,7 @@ describe Tmuxinator::Cli do
 
     # this command variant only works for tmux version 1.6 and up.
     context "from a session" do
-      context "with tmux >= 1.6", if: Tmuxinator::Config.version >= 1.6 do
+      context "with tmux >= 1.6", if: Tmuxinator::TmuxVersion.version >= 1.6 do
         before do
           # Necessary to make `Doctor.installed?` work in specs
           allow(Tmuxinator::Doctor).to receive(:installed?).and_return(true)
@@ -560,7 +560,7 @@ describe Tmuxinator::Cli do
       context "with tmux < 1.6" do
         before do
           ARGV.replace ["new", name, "sessionname"]
-          allow(Tmuxinator::Config).to receive(:version).and_return(1.5)
+          stub_tmux_version(1.5)
         end
 
         it "is unsupported" do
@@ -640,7 +640,7 @@ describe Tmuxinator::Cli do
 
     context "project config file" do
       before do
-        allow(Tmuxinator::Config).to receive_messages(version: 1.9)
+        stub_tmux_version(1.9)
         expect(Tmuxinator::Config).to receive(:validate).and_call_original
       end
 

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -138,12 +138,6 @@ describe Tmuxinator::Config do
     end
   end
 
-  describe "#sample" do
-    it "gets the path of the sample project" do
-      expect(described_class.sample).to include("sample.yml")
-    end
-  end
-
   describe "#default" do
     it "gets the path of the default config" do
       expect(described_class.default).to include("default.yml")

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -329,25 +329,25 @@ describe Tmuxinator::Config do
         end.to raise_error RuntimeError, regex
       end
 
-      it "should load and validate the project" do
+      it "should locate the project config file" do
         project_config = File.join(fixtures_dir, "sample.yml")
         expect(described_class.validate(project_config: project_config)).to \
-          be_a Tmuxinator::Project
+          be_a String
       end
 
       it "should take precedence over a named project" do
         allow(described_class).to receive_messages(directory: fixtures_dir)
         project_config = File.join(fixtures_dir, "sample_number_as_name.yml")
-        project = described_class.validate(name: "sample",
+        project_file_path = described_class.validate(name: "sample",
                                            project_config: project_config)
-        expect(project.name).to eq("222")
+        expect(project_file_path).to match /spec\/fixtures\/sample_number_as_name.yml$/
       end
 
       it "should take precedence over a local project" do
         expect(described_class).not_to receive(:local?)
         project_config = File.join(fixtures_dir, "sample_number_as_name.yml")
-        project = described_class.validate(project_config: project_config)
-        expect(project.name).to eq("222")
+        project_file_path = described_class.validate(project_config: project_config)
+        expect(project_file_path).to match /spec\/fixtures\/sample_number_as_name.yml$/
       end
     end
 
@@ -358,10 +358,10 @@ describe Tmuxinator::Config do
         end.to raise_error RuntimeError, %r{Project.+doesn't.exist}
       end
 
-      it "should load and validate the project" do
+      it "should validate the project" do
         expect(described_class).to receive_messages(directory: fixtures_dir)
         expect(described_class.validate(name: "sample")).to \
-          be_a Tmuxinator::Project
+          be_a String
       end
     end
 
@@ -377,9 +377,8 @@ describe Tmuxinator::Config do
         content = File.read(File.join(fixtures_dir, "sample.yml"))
 
         expect(File).to receive(:exist?).with(default).at_least(:once) { true }
-        expect(File).to receive(:read).with(default).and_return(content)
 
-        expect(described_class.validate).to be_a Tmuxinator::Project
+        expect(described_class.validate).to be_a String
       end
     end
 

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -150,30 +150,10 @@ describe Tmuxinator::Config do
     end
   end
 
-  describe "#version" do
-    subject { described_class.version }
-
-    before do
-      expect(Tmuxinator::Doctor).to receive(:installed?).and_return(true)
-      allow_any_instance_of(Kernel).to receive(:`).with(/tmux\s\-V/).
-        and_return("tmux #{version}")
-    end
-
-    context "master" do
-      let(:version) { "master" }
-      it { is_expected.to eq Float::INFINITY }
-    end
-
-    context "installed" do
-      let(:version) { "2.4" }
-      it { is_expected.to eq version.to_f }
-    end
-  end
-
   describe "#default_path_option" do
     context ">= 1.8" do
       before do
-        allow(described_class).to receive(:version).and_return(1.8)
+        allow(Tmuxinator::TmuxVersion).to receive(:version).and_return(1.8)
       end
 
       it "returns -c" do
@@ -183,7 +163,7 @@ describe Tmuxinator::Config do
 
     context "< 1.8" do
       before do
-        allow(described_class).to receive(:version).and_return(1.7)
+        allow(Tmuxinator::TmuxVersion).to receive(:version).and_return(1.7)
       end
 
       it "returns default-path" do

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -605,6 +605,10 @@ describe Tmuxinator::Project do
     it "should return an instance of the class if the file loads" do
       expect(described_class.load(path, options)).to be_a Tmuxinator::Project
     end
+
+    it "should populate the Project#name" do
+      expect(described_class.load(path, options).name).to eq "sample"
+    end
   end
 
   describe "::parse_settings" do

--- a/spec/lib/tmuxinator/tmux_version_spec.rb
+++ b/spec/lib/tmuxinator/tmux_version_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe Tmuxinator::TmuxVersion do
+  describe ".version" do
+    subject { described_class.version }
+
+    before do
+      expect(Tmuxinator::Doctor).to receive(:installed?).and_return(true)
+      allow_any_instance_of(Kernel).to receive(:`).with(/tmux\s\-V/).
+        and_return("tmux #{version}")
+    end
+
+    context "master" do
+      let(:version) { "master" }
+      it { is_expected.to eq Float::INFINITY }
+    end
+
+    context "installed" do
+      let(:version) { "2.4" }
+      it { is_expected.to eq version.to_f }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,8 +20,12 @@ FactoryBot.find_definitions
 # Custom Matchers
 require_relative "matchers/pane_matcher"
 
+# Helpers
+require_relative "support/tmux_version_helpers"
+
 RSpec.configure do |config|
   config.order = "random"
+  config.include TmuxVersionHelpers
 end
 
 # Copied from minitest.

--- a/spec/support/tmux_version_helpers.rb
+++ b/spec/support/tmux_version_helpers.rb
@@ -1,0 +1,6 @@
+module TmuxVersionHelpers
+  def stub_tmux_version(version)
+    allow(Tmuxinator::TmuxVersion).to receive_messages(version: version)
+  end
+end
+


### PR DESCRIPTION
This separates the concerns of locating and parsing the config file.

This will allow us to better isolate the Config class as a whole.

Config.validate now returns a string to the location of the config file.

Consumers of Config.validate are now responsible for executing their own
Project.load.

This was branched from #701 and is slightly dependent thereof. It can easily be extricated from that dependency if needed.

Any conflicts should resolve once #701 is merged.