### PR TITLE
add zshell completions for command aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Misc
+- add zshell completions for command aliases
+
 ## 1.1.1
 ### Bugfixes
 - increase min XDG version in gemspec in order to exclude broken release (#708)

--- a/completion/tmuxinator.zsh
+++ b/completion/tmuxinator.zsh
@@ -9,7 +9,7 @@ _tmuxinator() {
       'projects:: _describe -t projects "tmuxinator projects" projects'
   elif (( CURRENT == 3)); then
     case $words[2] in
-      copy|debug|delete|open|start)
+      copy|cp|c|debug|delete|rm|open|o|start|s|edit|e)
         _arguments '*:projects:($projects)'
       ;;
     esac


### PR DESCRIPTION
Up until now, in zsh you had to type out the full command
(like "tmuxinator start") for tab completions to work.
This makes it work for aliases too (like "tmuxinator s").