### PR TITLE
Specify socket in 'tmux_has_session?'

### DIFF
--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -170,7 +170,7 @@ module Tmuxinator
       # to server: Connection refused" error message and non-zero exit status
       # if no tmux sessions exist.
       # Please see issues #402 and #414.
-      sessions = `#{tmux_command} ls 2> /dev/null`
+      sessions = `#{tmux_command}#{socket} ls 2> /dev/null`
 
       # Remove any escape sequences added by `shellescape` in Project#name.
       # Escapes can result in: "ArgumentError: invalid multibyte character"


### PR DESCRIPTION
This fixes #719. The socket must be specified via 'socket_name' and not
via '

I tested  with the following configuration file,

```yaml
name: test
root: ~/

socket_name: foo

windows:
  - test_window:
      - echo $(date)
```
and it worked as expected.