### PR TITLE
Add 3.0 to supported tmux versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - "2.5.5"
   - "2.6.2"
 env:
+  - TMUX_VERSION=3.0a
+  - TMUX_VERSION=3.0
   - TMUX_VERSION=2.9a
   - TMUX_VERSION=2.9
   - TMUX_VERSION=2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Bugfixes
 - correct edge tmux version detection (#728)
 
+### Misc
+- add support for tmux 3.0 and 3.0a (#734)
+
 ## 1.1.2
 ### Bugfixes
 - prevent commands from being re-run when re-attaching to session using custom

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -1,6 +1,7 @@
 module Tmuxinator
   module TmuxVersion
     SUPPORTED_TMUX_VERSIONS = [
+      3.0,
       "2.9a",
       2.9,
       2.8,

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -1,6 +1,7 @@
 module Tmuxinator
   module TmuxVersion
     SUPPORTED_TMUX_VERSIONS = [
+      "3.0a",
       3.0,
       "2.9a",
       2.9,


### PR DESCRIPTION
I have not tested tmuxinator with tmux-3.0 thoroughly, but it _seems to work in my use case_.

I hope someone with more domain knowledge can review [tmux/CHANGES](https://github.com/tmux/tmux/blob/master/CHANGES) before merging.

Fixes #734.