### PR TITLE
Restore alias mux for zsh

### DIFF
--- a/completion/tmuxinator.zsh
+++ b/completion/tmuxinator.zsh
@@ -20,6 +20,8 @@ _tmuxinator() {
   return
 }
 
+complete -F _tmuxinator tmuxinator mux
+alias mux="tmuxinator"
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
🚩 **Summary**
In this specific commit : https://github.com/tmuxinator/tmuxinator/pull/737/commits/f149defef09251a9e2177626ca888e3041f5a11c#diff-10ce7fe3ff7170249062abe941ccd519L22

Aliase for mux in zsh has been removed, so I can't use the mux command in my terminal

⚠️ **Actual Result**
![zsh_mux](https://user-images.githubusercontent.com/34321859/72799607-e627cf00-3c45-11ea-99de-867bd1ff1748.png)

✔️ **Expected Result**
Can use the mux command