### PR TITLE
add shorthand alias for zsh completion

### DIFF
--- a/completion/tmuxinator.zsh
+++ b/completion/tmuxinator.zsh
@@ -20,6 +20,7 @@ _tmuxinator() {
   return
 }
 
+alias mux="tmuxinator"
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
The [shorthand alias](https://github.com/tmuxinator/tmuxinator#shorthand) for zsh completion is missing.