### PR TITLE
Update Ruby Support Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - "2.4.6"
-  - "2.5.5"
-  - "2.6.2"
-  - "2.7.0"
+  - "2.5.8"
+  - "2.6.6"
+  - "2.7.1"
 env:
   - TMUX_VERSION=3.0a
   - TMUX_VERSION=3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+## Unreleased
+- remove support for Ruby 2.4
+- bump patch versions of supported Rubies in Travis test matrix
+
 ## 1.1.5
 ### Misc
-- remove Ruby 2.4 from Travis test matrix
-- bump patch versions of supported Rubies in Travis test matrix
 - add support for tmux 3.1 (#754)
 - bump copyright year in README
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Misc
+- remove Ruby 2.4 from Travis test matrix
+- bump patch versions of supported Rubies in Travis test matrix
+
 ## 1.1.4
 ### Misc
 - bump Thor version to ~> 1.0 in order to accommodate Arch package and ecosystem

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   }
 
   s.required_rubygems_version = ">= 1.8.23"
-  s.required_ruby_version = ">= 2.4.6"
+  s.required_ruby_version = ">= 2.5.8"
 
   s.add_dependency "erubis", "~> 2.6"
   s.add_dependency "thor", "~> 1.0"


### PR DESCRIPTION
- Remove Ruby 2.4 from Travis config
- Update min required Ruby in gemspec
- Bump patches for supported Rubies