### PR TITLE
Bump XDG Dependency Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Misc
+- Bump XDG dependency to 3.0.1, which is the most up-to-date version aligned
+with tmuxinator's list of currently supported Rubies (#753)
+
 ## 1.1.4
 ### Misc
 - bump Thor version to ~> 1.0 in order to accommodate Arch package and ecosystem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## Unreleased
 - remove support for Ruby 2.4
 - bump patch versions of supported Rubies in gemspec and Travis config
+- bump XDG dependency to 3.0.1, which is the most up-to-date version aligned
+with tmuxinator's list of currently supported Rubies (#753)
 
 ## 1.1.5
 ### Misc
-- bump XDG dependency to 3.0.1, which is the most up-to-date version aligned
-with tmuxinator's list of currently supported Rubies (#753)
 - add support for tmux 3.1 (#754)
 - bump copyright year in README
 

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -29,7 +29,7 @@ module Tmuxinator
       # a custom value. (e.g. if $XDG_CONFIG_HOME is set to ~/my-config, the
       # return value will be ~/my-config/tmuxinator)
       def xdg
-        XDG["CONFIG"].to_s + "/tmuxinator"
+        XDG::Config.new.home.to_s + "/tmuxinator"
       end
 
       def xdg?

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -53,7 +53,8 @@ describe Tmuxinator::Config do
 
         Dir.mktmpdir do |dir|
           config_parent = "#{dir}/non_existant_parent/s"
-          allow(XDG).to receive(:[]).with("CONFIG").and_return config_parent
+          allow(XDG::Config).to receive_message_chain(:new, :home, :to_s).
+            and_return config_parent
           expect(described_class.directory).
             to eq "#{config_parent}/tmuxinator"
           expect(File.directory?("#{config_parent}/tmuxinator")).to be true
@@ -134,7 +135,8 @@ describe Tmuxinator::Config do
 
   describe "#xdg" do
     it "is $XDG_CONFIG_HOME/tmuxinator" do
-      expect(described_class.xdg).to eq "#{XDG['CONFIG_HOME']}/tmuxinator"
+      config_home = XDG::Config.new.home.to_s
+      expect(described_class.xdg).to eq "#{config_home}/tmuxinator"
     end
   end
 

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "erubis", "~> 2.6"
   s.add_dependency "thor", "~> 1.0"
-  s.add_dependency "xdg", "~> 2.2", ">= 2.2.5"
+  s.add_dependency "xdg", "~> 3.0.1"
 
   s.add_development_dependency "activesupport", "< 5.0.0" # Please see issue #432
   s.add_development_dependency "awesome_print", "~> 1.2"

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   }
 
   s.required_rubygems_version = ">= 1.8.23"
-  s.required_ruby_version = ">= 2.4.6"
+  s.required_ruby_version = ">= 2.5.8"
 
   s.add_dependency "erubis", "~> 2.6"
   s.add_dependency "thor", "~> 1.0"


### PR DESCRIPTION
- Bump XDG dependency to 3.0.1, which is the most up-to-date version aligned with tmuxinator's list of supported Rubies
- Address XDG API changes

Closes #753.