### PR TITLE
Synchronize YAML in README and sample.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Security
 - bump rake development dependency version to address CVE-2020-8130
 ### Misc
+- synchronize project configs in README and sample.yml
 - remove support for Ruby 2.4
 - bump patch versions of supported Rubies in gemspec and Travis config
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If this is a new project you will see this default config:
 name: sample
 root: ~/
 
-# Optional. tmux socket
+# Optional tmux socket
 # socket_name: foo
 
 # Note that the pre and post options have been deprecated and will be replaced by
@@ -136,11 +136,20 @@ root: ~/
 # tmux_command: byobu
 
 # Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
-# startup_window: logs
+# startup_window: editor
+
+# Specifies (by index) which pane of the specified window will be selected on project startup. If not set, the first pane is used.
+# startup_pane: 1
+
+# Controls whether the tmux session should be attached to automatically. Defaults to true.
+# attach: false
 
 windows:
   - editor:
       layout: main-vertical
+      # Synchronize all panes of this window, can be enabled before or after the pane commands run.
+      # 'before' represents legacy functionality and will be deprecated in a future release, in favour of 'after'
+      # synchronize: after
       panes:
         - vim
         - guard

--- a/lib/tmuxinator/assets/sample.yml
+++ b/lib/tmuxinator/assets/sample.yml
@@ -10,14 +10,19 @@ root: ~/
 # project hooks.
 
 # Project hooks
+
 # Runs on project start, always
 # on_project_start: command
+
 # Run on project start, the first time
 # on_project_first_start: command
+
 # Run on project start, after the first time
 # on_project_restart: command
+
 # Run on project exit ( detaching from tmux session )
 # on_project_exit: command
+
 # Run on project stop
 # on_project_stop: command
 


### PR DESCRIPTION
Synchronizes sample project yaml config in README and sample.yml.

- add empty lines to sample.yml
- add startup_pane option to README
- add attach to README
- add synchronize to README

Closes #765.