### PR TITLE
Document Removal of Zsh "mux" Alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Security
 - bump rake development dependency version to address CVE-2020-8130
 ### Misc
-- document removal of Zsh mux alias\; suggest users migrate to RC based aliases
+- document removal of Zsh mux alias; suggest users migrate to RC based aliases
 - synchronize project configs in README and sample.yml
 - remove support for Ruby 2.4
 - bump patch versions of supported Rubies in gemspec and Travis config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Security
 - bump rake development dependency version to address CVE-2020-8130
 ### Misc
+- document removal of Zsh mux alias\; suggest users migrate to RC based aliases
 - remove support for Ruby 2.4
 - bump patch versions of supported Rubies in gemspec and Travis config
 

--- a/README.md
+++ b/README.md
@@ -307,11 +307,13 @@ You can provide tmuxinator with a project config file using the optional `[proje
 
 ## Shorthand
 
-The [shell completion files](#completion) also include a shorthand alias for tmuxinator that can be used in place of the full name.
+The [shell completion files](#completion) also include a shorthand alias for tmuxinator that can be used in place of the full name*.
 
 ```
 mux [command]
 ```
+
+*The `mux` alias has been removed from the Zsh completion script because it was resulting in unexpected behavior in some setups. Including aliases in completion scripts is not standard practice and the Bash and Fish aliases may be removed in a future release. Going forward, users should create their own aliases in their shell's RC file (e.g. `alias mux=tmuxinator`).
 
 ## Other Commands
 


### PR DESCRIPTION
- Note the removal of the `mux` alias from the Zsh completion script
- Suggest users create their own aliases in their shell's RC file

Closes #749.