### PR TITLE
Fixes installation of a completion file for fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Note: ZSH's completion files can be put in other locations in your `$fpath`. Ple
 
 ### fish
 
-    $ wget https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/completion/tmuxinator.fish ~/.config/fish/completions/
+    $ wget https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/completion/tmuxinator.fish -O ~/.config/fish/completions/tmuxinator.fish
 
 ## Usage
 


### PR DESCRIPTION
The command in README in order to install a completion file for fish doesn't work. 
It looks need `-O` option as well as other examples.