### PR TITLE
fix error when parsing config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Fix config file parsing error: wrong number of arguments (given 4, expected 1) (#819)
+
 ## 2.0.3
 ### Misc
 - Add Ruby 3 to the Travis test matrix

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -48,7 +48,7 @@ module Tmuxinator
         @args = args
 
         content = Erubis::Eruby.new(raw_content).result(binding)
-        YAML.safe_load(content, [], [], true)
+        YAML.safe_load(content, aliases: true)
       rescue SyntaxError, StandardError => error
         raise "Failed to parse config file: #{error.message}"
       end


### PR DESCRIPTION
YAML parser returns wrong number of arguments(given 4, expected 1),
this fix removes the extra parameters, while still passing in the
allowAliases flag.