### PR TITLE
Bump tmuxinator to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## Unreleased
+## 3.0.0
+### Misc
 - Deprecate Ruby 2.5; bump min Ruby version in gemspec; bump Ruby versions in Travis test matrix
 - Fix config file parsing error: wrong number of arguments (given 4, expected 1) (#819)
 

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "2.0.3".freeze
+  VERSION = "3.0.0".freeze
 end


### PR DESCRIPTION
- Deprecate EOL'd versions of Ruby
- Fix method signature bug in Psych::safe_load