### PR TITLE
3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 3.1.0
 ### tmux
 - add tmux 3.2a to Travis test matrix; add 3.2a to supported tmux versions list
 ### Misc

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "3.0.0".freeze
+  VERSION = "3.0.1".freeze
 end


### PR DESCRIPTION
Bump tmuxinator to 3.1.0.

- add tmux 3.2a to Travis test matrix; add 3.2a to supported tmux versions list
- add support for local project configs using the .yaml extension