### PR TITLE
Fix broken link in README (#846)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ windows:
 ```
 
 The layout setting gets handed down to tmux directly, so you can choose from
-one of [the five standard layouts](http://manpages.ubuntu.com/manpages/precise/en/man1/tmux.1.html#contenttoc6)
+one of [the five standard layouts](https://manpages.org/tmux/1)
 or [specify your own](http://stackoverflow.com/a/9976282/183537).
 
 **Please note the indentation here is deliberate. YAML's indentation rules can be confusing, so if your config isn't working as expected, please check the indentation.** For a more detailed explanation of _why_ YAML behaves this way, see [this](https://stackoverflow.com/questions/50594758/why-isnt-two-spaced-yaml-parsed-like-four-spaced-yaml/50600253#50600253) Stack Overflow question.


### PR DESCRIPTION
I chose [this link](https://manpages.org/tmux/1) because it contains the same information as the previous page (as archived by the Wayback Machine from 2011 through 2021), in a clean and easy-to-read format.

If you'd like, I could also put together some screenshots of the various layouts and include it in a subsequent PR - but that seemed like overkill for this trivial change, and I wasn't sure you'd want to include the image files in this project's repository.