### PR TITLE
Bump tmuxinator to 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-## Unreleased
+## 3.0.2
 ### Third-party Dependencies
 - Bump Thor version to handle DidYouMean deprecation warning
 
 
-## 3.1.0
+## 3.0.1
 ### tmux
 - add tmux 3.2a to Travis test matrix; add 3.2a to supported tmux versions list
 ### Misc

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "3.0.1".freeze
+  VERSION = "3.0.2".freeze
 end


### PR DESCRIPTION
Bump tmuxinator to 3.0.2.

- Bump Thor dependency to fix DidYouMean deprecation warning (848)
- Fix version typo in CHANGELOG.md (3.1.0 => 3.0.1)