### PR TITLE
Fix out of date man page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Note: ZSH's completion files can be put in other locations in your `$fpath`. Ple
 ## Usage
 
 A working knowledge of tmux is assumed. You should understand what windows and
-panes are in tmux. If not please consult the [man pages](http://manpages.ubuntu.com/manpages/precise/en/man1/tmux.1.html#contenttoc6) for tmux.
+panes are in tmux. If not please consult the [man pages](https://manpages.ubuntu.com/manpages/jammy/en/man1/tmux.1.html) for tmux.
 
 ### Create a project
 


### PR DESCRIPTION
Previously the link redirect to an error page:
![CleanShot 2022-03-04 at 13 31 35](https://user-images.githubusercontent.com/796639/156837358-597e3dc4-a1d8-4a3e-9b32-b1f9fad13403.png)

