### PR TITLE
Bump tmuxinator to 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Unreleased
+## 3.0.3
 ### Misc
-- add tmux 3.3 to (currently defunct) Travis test matrix; add 3.3 to supported tmux versions list
 - use stable tmux links in README.md
+### tmux
+- add tmux 3.3 to (currently defunct) Travis test matrix; add 3.3 to supported tmux versions list
 
 ## 3.0.2
 ### Third-party Dependencies

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "3.0.2".freeze
+  VERSION = "3.0.3".freeze
 end


### PR DESCRIPTION
## 3.0.3
### Misc
- use stable tmux links in README.md
### tmux
- add tmux 3.3 to (currently defunct) Travis test matrix; add 3.3 to supported tmux versions list