### PR TITLE
fix tmux 3.3 version

### DIFF
--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -1,7 +1,7 @@
 module Tmuxinator
   module TmuxVersion
     SUPPORTED_TMUX_VERSIONS = [
-      "3.3",
+      3.3,
       "3.2a",
       3.2,
       "3.1c",


### PR DESCRIPTION
Fix issue #861 

Run tmuxinator on tmux 3.3 show warning that version is unsupported. This commit fix tmux version declared inside tmux_version to not use string.