### PR TITLE
Fix tmux 3.3 version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+### tmux
+- fix tmux 3.3 version detection
+
 ## 3.0.3
 ### Misc
 - use stable tmux links in README.md

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -1,7 +1,7 @@
 module Tmuxinator
   module TmuxVersion
     SUPPORTED_TMUX_VERSIONS = [
-      "3.3",
+      3.3,
       "3.2a",
       3.2,
       "3.1c",


### PR DESCRIPTION
The initial version of tmuxinator which added support for tmux 3.3 was checking the tmux version against a string when it should have been using a float. This whole approach is way too brittle and should really be rethought.