### PR TITLE
Remove `mux` alias in Bash completion file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Misc
 - Fix typos and remove extra whitespace
+- Remove `mux` alias from Fish and Bash completions
 
 ## 3.1.0
 - add a FAQ entry about how long commands may be lost/corrupted by TTY typeahead

--- a/completion/tmuxinator.bash
+++ b/completion/tmuxinator.bash
@@ -19,5 +19,4 @@ _tmuxinator() {
     fi
 }
 
-complete -F _tmuxinator tmuxinator mux
-alias mux="tmuxinator"
+complete -F _tmuxinator tmuxinator

--- a/completion/tmuxinator.fish
+++ b/completion/tmuxinator.fish
@@ -20,5 +20,3 @@ complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_comman
 complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command open'      -a "(__fish_tmuxinator_program completions open)"
 complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command copy'      -a "(__fish_tmuxinator_program completions copy)"
 complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command delete'    -a "(__fish_tmuxinator_program completions delete)"
-
-abbr --add mux "tmuxinator"


### PR DESCRIPTION
It should be removed because:

- Aliases in completion files are unconventional
- This will conflict with user-defined aliases in unexpected and hard-to-debug ways
- It is not consistent with completions for the other shells that we support (zsh)
- Is confusing

Closes #868