### PR TITLE
FAQ: commands may be lost or corrupted when TTY typeahead buffer is full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- add a FAQ entry about how long commands may be lost/corrupted by TTY typeahead
+
 ## 3.0.5
 ### tmux
 - add tmux 3.3a to (currently defunct) Travis test matrix; add 3.3a to supported tmux versions list

--- a/README.md
+++ b/README.md
@@ -390,6 +390,12 @@ creating or searching for existing project configuration files:
 
 Add `export DISABLE_AUTO_TITLE=true` to your `.zshrc` or `.bashrc`
 
+### Commands being lost or corrupted
+
+If a lot of commands or long commands are sent to a pane, and commands or characters seem to be lost or corrupted, it could be that the TTY typeahead buffer is full and losing new characters. This may happen when an earlier command takes a long time to complete. This seems to affect macOS with zsh more than other platforms.
+
+When this occurs, try putting your commands in a separate script and calling that from your tmuxinator configuration using e.g.: `source`.
+
 ## Contributing
 
 To contribute, please read the [contributing guide](https://github.com/tmuxinator/tmuxinator/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
At my work, we recently experienced issues with our tmuxinator configuration where characters seemed to be lost or commands corrupted. I investigated this and found it might be due to an issue with the TTY typeahead buffer filling up and dropping characters. It was resolved by splitting long commands out into a separate script, which could then be loaded up using `source`. In this case, there were a lot of commands in `pre_window`.

I've added a FAQ entry covering this case, because I wasn't sure where else to document it. It does not seem like a widely known issue - it's hard to find with Google or ChatGPT. But the impact of it is pretty big, so I think it should be documented.

---

Here are my notes from my PR at work that resolved the issue for us:

It turns out that there is a tty readahead buffer limit of 1,024 characters on macOS, which is hard-coded in the kernel. So if you paste a bunch of input into a session quickly, and the terminal doesn't read it quick enough, characters can get lost. There are a few reports of this that I've seen, e.g.: [command limits when pasting into tcsh (mac OS X)](https://superuser.com/a/219304), and [Unbracketed pastes of > 1024 characters on macos drop or repeat characters](https://github.com/kovidgoyal/kitty/issues/5869#issuecomment-1377128383) and [another comment on the same issue](https://github.com/kovidgoyal/kitty/issues/5869#issuecomment-1377802196).

tmuxinator uses `tmux send-keys` to send the commands to the sessions. You can see what it has sent using `tmux show-messages`. You can use something like this to see what's being executed in the services window: `tmux show-messages | grep dev:2 | grep send-keys | perl -pe 's/^.*dev:2 //;' | wc -c`. That was about 1,080 ish characters before this PR.

It doesn't seem like there's any way to influence zsh or bash to read quicker.

The solution I've adopted in this PR is to split out all the environment variables into a separate script that can be loaded in using `source`. That reduces the commands in the services window in tmuxinator to < 400.

It seems to work pretty reliably with zsh for me now.