### PR TITLE
docs: fish completions file not downloaded to correct directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note: ZSH's completion files can be put in other locations in your `$fpath`. Ple
 
 ### fish
 
-    $ wget https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/completion/tmuxinator.fish ~/.config/fish/completions/
+    wget https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/completion/tmuxinator.fish -O ~/.config/fish/completions/tmuxinator.fish
 
 ## Usage
 


### PR DESCRIPTION
The command given in the README.md downloads the fish file to the current working directory instead of to the provided directory, because the `-O` option is left out. Additionally, the `-O` option's value must a file, not a directory.

Having the `$` sign at the start of the given command is inconvenient, because, after copying and pasting, one has to firstly delete it.