### PR TITLE
refactor: Replace exists? with exist? for Ruby >= 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Fixes
 - Shell escape pane titles to fix multi word and special character titles
+- Replace exists? with exist? for Ruby >= 3.2
 
 ## 3.1.2
 ### Fixes

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -341,12 +341,12 @@ module Tmuxinator
       new_config_path = Tmuxinator::Config.project(new)
 
       exit!("Project #{existing} doesn't exist!") \
-        unless Tmuxinator::Config.exists?(name: existing)
+        unless Tmuxinator::Config.exist?(name: existing)
 
-      new_exists = Tmuxinator::Config.exists?(name: new)
+      new_exists = Tmuxinator::Config.exist?(name: new)
       question = "#{new} already exists, would you like to overwrite it?"
       if !new_exists || yes?(question, :red)
-        say "Overwriting #{new}" if Tmuxinator::Config.exists?(name: new)
+        say "Overwriting #{new}" if Tmuxinator::Config.exist?(name: new)
         FileUtils.copy_file(existing_config_path, new_config_path)
       end
 
@@ -359,7 +359,7 @@ module Tmuxinator
 
     def delete(*projects)
       projects.each do |project|
-        if Tmuxinator::Config.exists?(name: project)
+        if Tmuxinator::Config.exist?(name: project)
           config = Tmuxinator::Config.project(project)
 
           if yes?("Are you sure you want to delete #{project}?(y/n)", :red)
@@ -433,7 +433,7 @@ module Tmuxinator
       if args.empty? && Tmuxinator::Config.local?
         Tmuxinator::Cli.new.local
       elsif name && !Tmuxinator::Cli::RESERVED_COMMANDS.include?(name) &&
-            Tmuxinator::Config.exists?(name: name)
+            Tmuxinator::Config.exist?(name: name)
         Tmuxinator::Cli.new.start(name, *args.drop(1))
       else
         Tmuxinator::Cli.start(args)

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -57,7 +57,7 @@ module Tmuxinator
       end
 
       def default?
-        exists?(name: "default")
+        exist?(name: "default")
       end
 
       def version
@@ -76,7 +76,7 @@ module Tmuxinator
         version && version < 1.8 ? "default-path" : "-c"
       end
 
-      def exists?(name: nil, path: nil)
+      def exist?(name: nil, path: nil)
         return File.exist?(path) if path
         return File.exist?(project(name)) if name
         false
@@ -140,7 +140,7 @@ module Tmuxinator
 
       def valid_project_config?(project_config)
         return false unless project_config
-        unless exists?(path: project_config)
+        unless exist?(path: project_config)
           raise "Project config (#{project_config}) doesn't exist."
         end
         true
@@ -154,7 +154,7 @@ module Tmuxinator
 
       def valid_standard_project?(name)
         return false unless name
-        raise "Project #{name} doesn't exist." unless exists?(name: name)
+        raise "Project #{name} doesn't exist." unless exist?(name: name)
         true
       end
 

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -15,7 +15,7 @@ describe Tmuxinator::Cli do
       File.new(local_project_path, "w").tap do |f|
         f.write content
       end.close
-      expect(File.exists?(local_project_path)).to be_truthy
+      expect(File.exist?(local_project_path)).to be_truthy
       expect(File.read(local_project_path)).to eq content
     end
 
@@ -93,7 +93,7 @@ describe Tmuxinator::Cli do
         context "a tmuxinator project name" do
           before do
             expect(Tmuxinator::Config).to \
-              receive(:exists?).with(name: arg1) { true }
+              receive(:exist?).with(name: arg1) { true }
           end
 
           it "should call #start" do
@@ -127,7 +127,7 @@ describe Tmuxinator::Cli do
         context "something else" do
           before do
             expect(Tmuxinator::Config).to \
-              receive(:exists?).with(name: arg1) { false }
+              receive(:exist?).with(name: arg1) { false }
           end
 
           it "should call ::start" do
@@ -622,7 +622,7 @@ describe Tmuxinator::Cli do
   describe "#copy" do
     before do
       ARGV.replace(["copy", "foo", "bar"])
-      allow(Tmuxinator::Config).to receive(:exists?) { true }
+      allow(Tmuxinator::Config).to receive(:exist?) { true }
     end
 
     context "new project already exists" do
@@ -638,7 +638,7 @@ describe Tmuxinator::Cli do
 
     context "existing project doesn't exist" do
       before do
-        allow(Tmuxinator::Config).to receive(:exists?) { false }
+        allow(Tmuxinator::Config).to receive(:exist?) { false }
       end
 
       it "exit with error code" do
@@ -714,7 +714,7 @@ describe Tmuxinator::Cli do
 
       context "project exists" do
         before do
-          allow(Tmuxinator::Config).to receive(:exists?) { true }
+          allow(Tmuxinator::Config).to receive(:exist?) { true }
         end
 
         it "deletes the project" do
@@ -725,7 +725,7 @@ describe Tmuxinator::Cli do
 
       context "local project exists" do
         before do
-          allow(Tmuxinator::Config).to receive(:exists?) { true }
+          allow(Tmuxinator::Config).to receive(:exist?) { true }
           expect(Tmuxinator::Config).to receive(:project) { "local" }
         end
 
@@ -737,7 +737,7 @@ describe Tmuxinator::Cli do
 
       context "project doesn't exist" do
         before do
-          allow(Tmuxinator::Config).to receive(:exists?) { false }
+          allow(Tmuxinator::Config).to receive(:exist?) { false }
         end
 
         it "outputs an error message" do
@@ -754,7 +754,7 @@ describe Tmuxinator::Cli do
 
       context "all projects exist" do
         before do
-          allow(Tmuxinator::Config).to receive(:exists?).and_return(true)
+          allow(Tmuxinator::Config).to receive(:exist?).and_return(true)
         end
 
         it "deletes the projects" do
@@ -765,10 +765,10 @@ describe Tmuxinator::Cli do
 
       context "only one project exists" do
         before do
-          allow(Tmuxinator::Config).to receive(:exists?).with(name: "foo") {
+          allow(Tmuxinator::Config).to receive(:exist?).with(name: "foo") {
             true
           }
-          allow(Tmuxinator::Config).to receive(:exists?).with(name: "bar") {
+          allow(Tmuxinator::Config).to receive(:exist?).with(name: "bar") {
             false
           }
         end
@@ -785,7 +785,7 @@ describe Tmuxinator::Cli do
 
       context "all projects do not exist" do
         before do
-          allow(Tmuxinator::Config).to receive(:exists?).and_return(false)
+          allow(Tmuxinator::Config).to receive(:exist?).and_return(false)
         end
 
         it "outputs multiple error messages" do

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -262,14 +262,14 @@ describe Tmuxinator::Config do
     end
   end
 
-  describe "#exists?" do
+  describe "#exist?" do
     before do
       allow(File).to receive_messages(exist?: true)
       allow(described_class).to receive_messages(project: "")
     end
 
     it "checks if the given project exists" do
-      expect(described_class.exists?(name: "test")).to be_truthy
+      expect(described_class.exist?(name: "test")).to be_truthy
     end
   end
 


### PR DESCRIPTION
### Problem

Support for `.exists?` for File and Dir was removed from Ruby here: https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2

It has been deprecated since ruby 2.1:
https://github.com/ruby/ruby/commit/22a961383a4c3519f5d807f0986168ec1ec2bebf

Here's an example error, from https://github.com/tmuxinator/tmuxinator/pull/896:

```
  3) Tmuxinator::Cli::bootstrap and there is a local project config when one or more args are supplied it should behave like bootstrap_with_arguments and the first arg is a tmuxinator project name should call #start
     Failure/Error: expect(File.exists?(local_project_path)).to be_truthy

     NoMethodError:
       undefined method `exists?' for File:Class
     Shared Example Group: :bootstrap_with_arguments called from ./spec/lib/tmuxinator/cli_spec.rb:154
     # ./spec/lib/tmuxinator/cli_spec.rb:18:in `block (3 levels) in <top (required)>'
```

### Solution

Replace `exists?` with `exist?`

Note that this also changes `Tmuxinator::Config.exists?` to `Tmuxinator::Config.exist?` to reduce confusion and to better align with the ruby standard library.

### More info

This was done in the past:
https://github.com/tmuxinator/tmuxinator/commit/c18dfe85746eadfc3146b83c20c6e1e3f86f11b1

While it doesn't look like we're ready to officially support (i.e. test in CI) Ruby 3.2 yet, it's still possible to successfully run tmuxinator in that environment. I found this issue while doing so, and it's a fairly [well known](https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/) Ruby backwards incompatibility.

The tests pass locally for me against ruby 3.1 and 3.2 with this change, but rubocop doesn't work properly, otherwise, we'd probably be able to add CI targets for 3.1. and 3.2.