### PR TITLE
Update stop command to support project-config and omitting project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+- add support for stop command without project name
+- add support for optional `--project-config` flag to `tmuxinator stop` command
+
 ## 3.1.0
 - add a FAQ entry about how long commands may be lost/corrupted by TTY typeahead
 - increment thor minor version in tmuxinator.gemspec

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -264,14 +264,23 @@ module Tmuxinator
       render_project(project)
     end
 
-    desc "stop [PROJECT]", COMMANDS[:stop]
+    desc "stop [PROJECT] [ARGS]", COMMANDS[:stop]
     map "st" => :stop
+    method_option "project-config", aliases: "-p",
+                                    desc: "Path to project config file"
     method_option "suppress-tmux-version-warning",
                   desc: "Don't show a warning for unsupported tmux versions"
 
-    def stop(name)
+    def stop(name = nil)
+      # project-config takes precedence over a named project in the case that
+      # both are provided.
+      if options["project-config"]
+        name = nil
+      end
+
       params = {
-        name: name
+        name: name,
+        project_config: options["project-config"]
       }
       show_version_warning if version_warning?(
         options["suppress-tmux-version-warning"]


### PR DESCRIPTION
Brings stop command in line with start command.

Can now stop a project started with the `--project-config` flag by running a stop command with the same flag. For instance the example in the README.md can now be stopped:
```
tmuxinator start --project-config=path/to/my-project.yaml
tmuxinator stop --project-config=path/to/my-project.yaml
```

Stopping the default local project (`./.tmuxinator.yml`) is now easier and matches the short way or starting it:
`tmuxinator start` to start, `tmuxinator stop` to stop. I think this then closes #626.

---

My use case is having multiple local `.yml` project config files which have different `on_project_start` tasks that need to be cleaned up with a corresponding `on_project_stop`. Currently there is no way to get the `on_project_stop` hook to run if you started the project using the `--project-config` flag.