### PR TITLE
Set pane title if provided in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 3.1.0
 - add a FAQ entry about how long commands may be lost/corrupted by TTY typeahead
 - increment thor minor version in tmuxinator.gemspec
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+- Set pane title if provided in config file
+
 ## 3.1.0
 - add a FAQ entry about how long commands may be lost/corrupted by TTY typeahead
 - increment thor minor version in tmuxinator.gemspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.0
+## Unreleased
 - Set pane title if provided in config file
 
 ## 3.1.0

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ for a workaround.
 
 ### Pane titles
 
-It is also possible to give a title to panes.
+It is also possible (starting with tmux v2.6) to give a title to panes.
 
 ```yaml
 windows:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,27 @@ be due [#651](https://github.com/tmuxinator/tmuxinator/issues/651). See [this
 comment](https://github.com/tmuxinator/tmuxinator/issues/651#issuecomment-497780424)
 for a workaround.
 
+### Pane titles
+
+It is also possible to give a title to panes.
+
+```yaml
+windows:
+  - editor:
+      layout: main-vertical
+      panes:
+        - editor:
+          - vim
+        - guard
+```
+
+**Note:** For the titles to display you will need to modify your .tmux.conf with the following entries.
+
+```
+set -g pane-border-format "#{pane_index} #{pane_title}"
+set -g pane-border-status bottom
+```
+
 ## Interpreter Managers & Environment Variables
 
 To use tmuxinator with rbenv, RVM, NVM etc, use the `pre_window` option.

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -53,7 +53,7 @@ cd <%= root || "." %>
       <% end %>
     <% else %>
       <% window.panes.each do |pane| %>
-        <% unless pane.title.nil? %>
+        <% unless Tmuxinator::Config.version < 2.6 %>
   <%= pane.tmux_set_title %>
         <% end %>
         <% if pane.project.pre_window %>

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -53,6 +53,9 @@ cd <%= root || "." %>
       <% end %>
     <% else %>
       <% window.panes.each do |pane| %>
+        <% unless pane.title.nil? %>
+  <%= pane.tmux_set_title %>
+        <% end %>
         <% if pane.project.pre_window %>
   <%= pane.tmux_pre_window_command %>
         <% end %>

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -70,7 +70,8 @@ module Tmuxinator
     end
 
     def _set_title(title)
-      "#{project.tmux} select-pane -t #{tmux_window_and_pane_target} -T #{title}"
+      target = tmux_window_and_pane_target
+      "#{project.tmux} select-pane -t #{target} -T #{title}"
     end
   end
 end

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -1,12 +1,13 @@
 module Tmuxinator
   class Pane
-    attr_reader :commands, :project, :index, :tab
+    attr_reader :commands, :project, :index, :tab, :title
 
-    def initialize(index, project, tab, *commands)
+    def initialize(index, project, tab, *commands, title: nil)
       @commands = commands
       @index = index
       @project = project
       @tab = tab
+      @title = title
     end
 
     def tmux_window_and_pane_target
@@ -26,6 +27,12 @@ module Tmuxinator
         _send_target(command.shellescape)
       else
         ""
+      end
+    end
+
+    def tmux_set_title
+      unless title.nil?
+        _set_title(title)
       end
     end
 
@@ -60,6 +67,10 @@ module Tmuxinator
 
     def _send_keys(t, e)
       "#{project.tmux} send-keys -t #{t} #{e} C-m"
+    end
+
+    def _set_title(title)
+      "#{project.tmux} select-pane -t #{tmux_window_and_pane_target} -T #{title}"
     end
   end
 end

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "3.0.5".freeze
+  VERSION = "3.1.0".freeze
 end

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -59,7 +59,9 @@ module Tmuxinator
                       pane_yml
                     end
 
-        Tmuxinator::Pane.new(index, project, self, *commands)
+        title = pane_yml.is_a?(Hash) ? pane_yml.keys.first : nil
+
+        Tmuxinator::Pane.new(index, project, self, *commands, title: title)
       end.flatten
     end
 

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -50,16 +50,14 @@ module Tmuxinator
       return if panes_yml.nil?
 
       Array(panes_yml).map.with_index do |pane_yml, index|
-        commands =  case pane_yml
-                    when Hash
-                      pane_yml.values.first
-                    when Array
-                      pane_yml
-                    else
-                      pane_yml
-                    end
-
-        title = pane_yml.is_a?(Hash) ? pane_yml.keys.first : nil
+        commands, title = case pane_yml
+                          when Hash
+                            [pane_yml.values.first, pane_yml.keys.first]
+                          when Array
+                            [pane_yml, nil]
+                          else
+                            [pane_yml, nil]
+                          end
 
         Tmuxinator::Pane.new(index, project, self, *commands, title: title)
       end.flatten

--- a/spec/lib/tmuxinator/pane_spec.rb
+++ b/spec/lib/tmuxinator/pane_spec.rb
@@ -3,19 +3,20 @@ require "spec_helper"
 describe Tmuxinator::Pane do
   let(:klass) { described_class }
   let(:instance) { klass.new(index, project, window, *commands) }
-  # let(:index) { "vim" }
-  # let(:project) { 0 }
-  # let(:tab) { nil }
-  # let(:commands) { nil }
+  let(:instance_with_title) do
+    klass.new(index, project, window, *commands, title: title)
+  end
   let(:index) { 0 }
   let(:project) { double }
   let(:window) { double }
   let(:commands) { ["vim", "bash"] }
+  let(:title) { "test" }
 
   before do
     allow(project).to receive(:name).and_return "foo"
     allow(project).to receive(:base_index).and_return 0
     allow(project).to receive(:pane_base_index).and_return 1
+    allow(project).to receive(:tmux).and_return "tmux"
 
     allow(window).to receive(:project).and_return project
     allow(window).to receive(:index).and_return 0
@@ -28,4 +29,18 @@ describe Tmuxinator::Pane do
   end
 
   it { expect(subject.tmux_window_and_pane_target).to eql "foo:0.1" }
+
+  it "does not set pane title" do
+    expect(subject.tmux_set_title).to be_nil
+  end
+
+  context "when title is provided" do
+    subject { instance_with_title }
+
+    it "sets pane title" do
+      expect(subject.tmux_set_title).to eql(
+        "tmux select-pane -t foo:0.1 -T test"
+      )
+    end
+  end
 end

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -127,6 +127,26 @@ describe Tmuxinator::Window do
       end
     end
 
+    context "titled panes" do
+      let(:panes) do
+        [
+          { "editor" => ["vim"] },
+          { "run" => ["cmd1", "cmd2"] },
+          "top"
+        ]
+      end
+
+      it "creates panes with titles" do
+        expect(window.panes).to match(
+          [
+            a_pane.with(index: 0, title: "editor").and_commands("vim"),
+            a_pane.with(index: 1, title: "run").and_commands("cmd1", "cmd2"),
+            a_pane.with(index: 2, title: nil).and_commands("top")
+          ]
+        )
+      end
+    end
+
     context "nested collections" do
       let(:command1) { "cd /tmp/" }
       let(:command2) { "ls" }


### PR DESCRIPTION
Pane titles are a commonly desired feature in tmux sessions (e.g. https://stackoverflow.com/questions/47800955/how-to-set-pane-titles-with-tmuxinator), but not explicitly supported by tmuxinator (although a pane can be named).

To pass a title to tmux it is generally required to use a somewhat hacky method, and run the command:
`printf '\033]2;%s\033\\' '<title>'` (`tmux select-pane -T <title>` is also supported).

Since tmuxinator already provides the ability to define a pane title, I thought I would take it a step further and pass that title to tmux. As it stands right now, tmux would still need to be configured with the appropriate settings to display the title, e.g.:
```
set -g pane-border-format "#{pane_index} #{pane_title}"
set -g pane-border-status bottom
```
but at least the title will be passed directly from the tmuxinator config, to tmux. As a follow up to this PR, we could make the pane title configuration part of the tmuxinator config.