### PR TITLE
Add configuration options for pane titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Fixes
 - Shell escape pane titles to fix multi word and special character titles
+- Add configuration options for pane titles
 
 ## 3.1.2
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -151,10 +151,11 @@ root: ~/
 # Enables the display of pane titles. For example "editor" below. Defaults to false.
 # enable_pane_titles: true
 
-# Configures pane title position. Either, bottom or top. Defaults to top.
+# Configures pane title position. Can be: bottom, top, or off. Defaults to top.
 # pane_title_position: bottom
 
 # Configures pane title format. Defaults to "#{pane_index}: #{pane_title}".
+# Please see the tmux manpage for details, on valid formats.
 # pane_title_format: " [ #T ] "
 
 windows:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ root: ~/
 # Controls whether the tmux session should be attached to automatically. Defaults to true.
 # attach: false
 
+# Enables the display of pane titles. For example "editor" below. Defaults to false.
+# enable_pane_titles: true
+
+# Configures pane title position. Either, bottom or top. Defaults to top.
+# pane_title_position: bottom
+
+# Configures pane title format. Defaults to "#{pane_index}: #{pane_title}".
+# pane_title_format: " [ #T ] "
+
 windows:
   - editor:
       layout: main-vertical
@@ -155,7 +164,8 @@ windows:
       # 'before' represents legacy functionality and will be deprecated in a future release, in favour of 'after'
       # synchronize: after
       panes:
-        - vim
+        - editor:
+          - vim
         - guard
   - server: bundle exec rails s
   - logs: tail -f log/development.log
@@ -222,6 +232,8 @@ for a workaround.
 It is also possible (starting with tmux v2.6) to give a title to panes.
 
 ```yaml
+enable_pane_titles: true
+
 windows:
   - editor:
       layout: main-vertical
@@ -229,13 +241,6 @@ windows:
         - editor:
           - vim
         - guard
-```
-
-**Note:** For the titles to display you will need to modify your .tmux.conf with the following entries.
-
-```
-set -g pane-border-format "#{pane_index} #{pane_title}"
-set -g pane-border-status bottom
 ```
 
 ## Interpreter Managers & Environment Variables

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ root: ~/
 # Enables the display of pane titles. For example "editor" below. Defaults to false.
 # enable_pane_titles: true
 
-# Configures pane title position. Can be: bottom, top, or off. Defaults to top.
+# Configures pane title position. Can be: bottom, top, or "off". Note: "off" must be provided in quotes to avoid being interpreted as a boolean false. Defaults to top.
 # pane_title_position: bottom
 
 # Configures pane title format. Defaults to "#{pane_index}: #{pane_title}".

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -37,6 +37,9 @@ cd <%= root || "." %>
     <% if Tmuxinator::Config.version < 2.6 %>
   <%= pane_titles_not_supported_warning %>
     <%- else -%>
+      <% if pane_title_position? && !pane_title_position_valid? %>
+  <%= pane_title_position_not_valid_warning %>
+      <% end %>
   <%= tmux_set_pane_title_position %>
   <%= tmux_set_pane_title_format %>
     <% end %>

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -33,6 +33,15 @@ cd <%= root || "." %>
     <% end %>
   <% end %>
 
+  <% if enable_pane_titles? %>
+    <% if Tmuxinator::Config.version < 2.6 %>
+  <%= pane_titles_not_supported_warning %>
+    <%- else -%>
+  <%= tmux_set_pane_title_position %>
+  <%= tmux_set_pane_title_format %>
+    <% end %>
+  <% end %>
+
   # Create other windows.
   <% windows.drop(1).each do |window| %>
   <%= window.tmux_new_window_command %>

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -352,7 +352,7 @@ module Tmuxinator
       if pane_title_format?
         "#{tmux} set pane-border-format \"#{yaml['pane_title_format']}\""
       else
-        "#{tmux} set pane-border-format " + %q("#{pane_index}: #{pane_title}")
+        "#{tmux} set pane-border-format \"\#{pane_index}: \#{pane_title}\""
       end
     end
 

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -336,6 +336,42 @@ module Tmuxinator
       "#{tmux} kill-session -t #{name}"
     end
 
+    def enable_pane_titles?
+      yaml["enable_pane_titles"]
+    end
+
+    def tmux_set_pane_title_position
+      if pane_title_position? && pane_title_position_valid?
+        "#{tmux} set pane-border-status #{yaml['pane_title_position']}"
+      else
+        "#{tmux} set pane-border-status top"
+      end
+    end
+
+    def tmux_set_pane_title_format
+      if pane_title_format?
+        "#{tmux} set pane-border-format \"#{yaml['pane_title_format']}\""
+      else
+        "#{tmux} set pane-border-format " + '"#{pane_index}: #{pane_title}"'
+      end
+    end
+
+    def pane_title_position_not_valid_warning
+      print_warning(
+        "The specified pane title position " +
+        "\"#{yaml['pane_title_position']}\" is not valid. " +
+        "Please choose one of: top, bottom, or off."
+      )
+    end
+
+    def pane_titles_not_supported_warning
+      print_warning(
+        "You have enabled pane titles in your configuration, " +
+        "but the feature is not supported by your version of tmux.\n" +
+        "Please consider upgrading to a version that supports it (tmux >=2.6)."
+      )
+    end
+
     private
 
     def blank?(object)
@@ -382,41 +418,22 @@ module Tmuxinator
       yaml["tmux_command"] == "wemux"
     end
 
-    def enable_pane_titles?
-      yaml["enable_pane_titles"]
-    end
-
-    def tmux_set_pane_title_position
-      if pane_title_position?
-        "#{tmux} set pane-border-status #{yaml['pane_title_position']}"
-      else
-        "#{tmux} set pane-border-status top"
-      end
-    end
-
     def pane_title_position?
       yaml["pane_title_position"]
     end
 
-    def tmux_set_pane_title_format
-      if pane_title_format?
-        "#{tmux} set pane-border-format \"#{yaml['pane_title_format']}\""
-      else
-        "#{tmux} set pane-border-format " + '"#{pane_index}: #{pane_title}"'
-      end
+    def pane_title_position_valid?
+      ["top", "bottom", "off"].include? yaml["pane_title_position"]
     end
 
     def pane_title_format?
       yaml["pane_title_format"]
     end
 
-    def pane_titles_not_supported_warning
+    def print_warning(message)
       yellow = '\033[1;33m'
       no_color = '\033[0m'
-      msg = "WARNING: You have enabled pane titles in your configuration, " +
-            "but the feature is not supported by your version of tmux.\n" +
-            "Please consider upgrading to a version that supports it " +
-            "(tmux >=2.6).\n"
+      msg = "WARNING: #{message}\n"
       "printf \"#{yellow}#{msg}#{no_color}\""
     end
   end

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -381,5 +381,42 @@ module Tmuxinator
     def wemux?
       yaml["tmux_command"] == "wemux"
     end
+
+    def enable_pane_titles?
+      yaml["enable_pane_titles"]
+    end
+
+    def tmux_set_pane_title_position
+      if pane_title_position?
+        "#{tmux} set pane-border-status #{yaml['pane_title_position']}"
+      else
+        "#{tmux} set pane-border-status top"
+      end
+    end
+
+    def pane_title_position?
+      yaml["pane_title_position"]
+    end
+
+    def tmux_set_pane_title_format
+      if pane_title_format?
+        x = "#{tmux} set pane-border-format \"#{yaml['pane_title_format']}\""
+      else
+        x = "#{tmux} set pane-border-format " + '"#{pane_index}: #{pane_title}"'
+      end
+    end
+
+    def pane_title_format?
+      yaml["pane_title_format"]
+    end
+
+    def pane_titles_not_supported_warning
+      yellow = '\033[1;33m'
+      no_color = '\033[0m'
+      msg = "WARNING: You have enabled pane titles in your configuration, " +
+      "but the feature is not supported by your version of tmux.\nPlease " +
+      "consider upgrading to a version that supports it (tmux >=2.6).\n"
+      "printf \"#{yellow}#{msg}#{no_color}\""
+    end
   end
 end

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -352,7 +352,7 @@ module Tmuxinator
       if pane_title_format?
         "#{tmux} set pane-border-format \"#{yaml['pane_title_format']}\""
       else
-        "#{tmux} set pane-border-format " + '"#{pane_index}: #{pane_title}"'
+        "#{tmux} set pane-border-format " + %q("#{pane_index}: #{pane_title}")
       end
     end
 

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -400,9 +400,9 @@ module Tmuxinator
 
     def tmux_set_pane_title_format
       if pane_title_format?
-        x = "#{tmux} set pane-border-format \"#{yaml['pane_title_format']}\""
+        "#{tmux} set pane-border-format \"#{yaml['pane_title_format']}\""
       else
-        x = "#{tmux} set pane-border-format " + '"#{pane_index}: #{pane_title}"'
+        "#{tmux} set pane-border-format " + '"#{pane_index}: #{pane_title}"'
       end
     end
 
@@ -414,8 +414,9 @@ module Tmuxinator
       yellow = '\033[1;33m'
       no_color = '\033[0m'
       msg = "WARNING: You have enabled pane titles in your configuration, " +
-      "but the feature is not supported by your version of tmux.\nPlease " +
-      "consider upgrading to a version that supports it (tmux >=2.6).\n"
+            "but the feature is not supported by your version of tmux.\n" +
+            "Please consider upgrading to a version that supports it " +
+            "(tmux >=2.6).\n"
       "printf \"#{yellow}#{msg}#{no_color}\""
     end
   end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -635,4 +635,71 @@ describe Tmuxinator::Project do
       end.to raise_error RuntimeError, %r{didn't.specify.a.'project_name'}
     end
   end
+
+  describe "#pane_titles" do
+    before do
+      allow(project).to receive(:tmux).and_return "tmux"
+    end
+
+    context "pane_titles not enabled" do
+      before { project.yaml["enable_pane_titles"] = false }
+
+      it "returns false" do
+        expect(project.enable_pane_titles?).to eq(false)
+      end
+    end
+
+    context "pane_titles enabled" do
+      before { project.yaml["enable_pane_titles"] = true }
+
+      it "returns true" do
+        expect(project.enable_pane_titles?).to eq(true)
+      end
+    end
+
+    context "pane_title_position not configured" do
+      before { project.yaml["pane_title_position"] = nil }
+
+      it "configures a default position of top" do
+        expect(project.tmux_set_pane_title_position).to eq(
+          "tmux set pane-border-status top")
+      end
+    end
+
+    context "pane_title_position configured" do
+      before { project.yaml["pane_title_position"] = "bottom" }
+
+      it "configures a position of bottom" do
+        expect(project.tmux_set_pane_title_position).to eq(
+          "tmux set pane-border-status bottom")
+      end
+    end
+
+    context "pane_title_position invalid" do
+      before { project.yaml["pane_title_position"] = "other" }
+
+      it "configures the default position" do
+        expect(project.tmux_set_pane_title_position).to eq(
+          "tmux set pane-border-status top")
+      end
+    end
+
+    context "pane_title_format not configured" do
+      before { project.yaml["pane_title_format"] = nil }
+
+      it "configures a default format" do
+        expect(project.tmux_set_pane_title_format).to eq(
+          'tmux set pane-border-format "#{pane_index}: #{pane_title}"')
+      end
+    end
+
+    context "pane_title_format configured" do
+      before { project.yaml["pane_title_format"] = " [ #T ] " }
+
+      it "configures the provided format" do
+        expect(project.tmux_set_pane_title_format).to eq(
+          'tmux set pane-border-format " [ #T ] "')
+      end
+    end
+  end
 end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -645,7 +645,7 @@ describe Tmuxinator::Project do
       before { project.yaml["enable_pane_titles"] = false }
 
       it "returns false" do
-        expect(project.enable_pane_titles?).to eq(false)
+        expect(project.enable_pane_titles?).to be false
       end
     end
 
@@ -653,7 +653,7 @@ describe Tmuxinator::Project do
       before { project.yaml["enable_pane_titles"] = true }
 
       it "returns true" do
-        expect(project.enable_pane_titles?).to eq(true)
+        expect(project.enable_pane_titles?).to be true
       end
     end
 

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -662,7 +662,8 @@ describe Tmuxinator::Project do
 
       it "configures a default position of top" do
         expect(project.tmux_set_pane_title_position).to eq(
-          "tmux set pane-border-status top")
+          "tmux set pane-border-status top"
+        )
       end
     end
 
@@ -671,7 +672,8 @@ describe Tmuxinator::Project do
 
       it "configures a position of bottom" do
         expect(project.tmux_set_pane_title_position).to eq(
-          "tmux set pane-border-status bottom")
+          "tmux set pane-border-status bottom"
+        )
       end
     end
 
@@ -680,7 +682,8 @@ describe Tmuxinator::Project do
 
       it "configures the default position" do
         expect(project.tmux_set_pane_title_position).to eq(
-          "tmux set pane-border-status top")
+          "tmux set pane-border-status top"
+        )
       end
     end
 
@@ -689,7 +692,8 @@ describe Tmuxinator::Project do
 
       it "configures a default format" do
         expect(project.tmux_set_pane_title_format).to eq(
-          'tmux set pane-border-format "#{pane_index}: #{pane_title}"')
+          'tmux set pane-border-format "#{pane_index}: #{pane_title}"'
+        )
       end
     end
 
@@ -698,7 +702,8 @@ describe Tmuxinator::Project do
 
       it "configures the provided format" do
         expect(project.tmux_set_pane_title_format).to eq(
-          'tmux set pane-border-format " [ #T ] "')
+          'tmux set pane-border-format " [ #T ] "'
+        )
       end
     end
   end


### PR DESCRIPTION
Hi guys, as a follow up to my previous pull request (#891), I want to add configuration options to enable pane titles in tmuxinator without having to mess with tmux.conf. Before I go further with the development I wanted to get your feedback on what I have so far, and whether it fits with the tmuxinator mission. I have added 3 configuration options:

1. `enable_pane_titles`  # Enables pane titles by setting a default configuration for `pane-border-status` and `pane-border-format`
2. `pane_title_position`  # Overwrites the default `pane-border-status` with the users choice
3. `pane_title_format`  # Overwrites the default `pane-border-format` with the users choice