### PR TITLE
feat: Add Ruby 3.2 to the test matrix

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,6 +21,7 @@ engines:
     enabled: false
   rubocop:
     enabled: true
+    channel: rubocop-0-61-1
 ratings:
   paths:
   - Gemfile.lock

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config -g blame.ignoreRevsFile .git-blame-ignore-revs
+
+# chore: Fix rubocop failures
+# Author: Andrew Kofink <ajkofink@gmail.com>
+# Date:   Sat Mar 30 12:13:30 2024 -0400
+1aee1bc3615e431093e6301020572b16b89dfbae

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
+          - '3.2.3'
+          - '3.1.4'
           - '3.0.1'
           - '2.7.3'
           - '2.6.7'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,20 +1,13 @@
 AllCops:
-  Include:
-  - "**/*.podspec"
-  - "**/*.jbuilder"
-  - "**/*.opal"
-  - "**/Vagrantfile"
-  - "**/Berksfile"
-  - "**/Cheffile"
-  - "**/Vagabondfile"
   Exclude:
   - "vendor/**/*"
   - "db/schema.rb"
   DisplayCopNames: true
   StyleGuideCopsOnly: false
+  TargetRubyVersion: 2.6
 Rails:
   Enabled: false
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
   Enabled: true
@@ -22,7 +15,7 @@ Style/AccessModifierIndentation:
   SupportedStyles:
   - outdent
   - indent
-Style/AlignHash:
+Layout/AlignHash:
   Description: Align the elements of a hash literal if they span more than one line.
   Enabled: true
   EnforcedHashRocketStyle: key
@@ -33,7 +26,7 @@ Style/AlignHash:
   - always_ignore
   - ignore_implicit
   - ignore_explicit
-Style/AlignParameters:
+Layout/AlignParameters:
   Description: Align the parameters of a method call if they span more than one line.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
   Enabled: true
@@ -65,7 +58,7 @@ Style/BracesAroundHashParameters:
   - braces
   - no_braces
   - context_dependent
-Style/CaseIndentation:
+Layout/CaseIndentation:
   Description: Indentation of when in a case/when/[else/]end.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-when-to-case
   Enabled: true
@@ -109,7 +102,7 @@ Style/CommentAnnotation:
   - OPTIMIZE
   - HACK
   - REVIEW
-Style/DotPosition:
+Layout/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
   Enabled: true
@@ -117,26 +110,26 @@ Style/DotPosition:
   SupportedStyles:
   - leading
   - trailing
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   Description: Use empty lines between defs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods
   Enabled: true
   AllowAdjacentOneLineDefs: false
-Style/EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
   Description: Keeps track of empty lines around block bodies.
   Enabled: true
   EnforcedStyle: no_empty_lines
   SupportedStyles:
   - empty_lines
   - no_empty_lines
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   Description: Keeps track of empty lines around class bodies.
   Enabled: true
   EnforcedStyle: no_empty_lines
   SupportedStyles:
   - empty_lines
   - no_empty_lines
-Style/EmptyLinesAroundModuleBody:
+Layout/EmptyLinesAroundModuleBody:
   Description: Keeps track of empty lines around module bodies.
   Enabled: true
   EnforcedStyle: no_empty_lines
@@ -147,16 +140,12 @@ Style/Encoding:
   Description: Use UTF-8 as the source file encoding.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
   Enabled: false
-  EnforcedStyle: always
-  SupportedStyles:
-  - when_needed
-  - always
-Style/FileName:
+Naming/FileName:
   Description: Use snake_case for source file names.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
   Enabled: false
   Exclude: []
-Style/FirstParameterIndentation:
+Layout/FirstParameterIndentation:
   Description: Checks the indentation of the first parameter in a method call.
   Enabled: true
   EnforcedStyle: special_for_inner_method_call_in_parentheses
@@ -204,13 +193,12 @@ Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
-  MaxLineLength: 80
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Description: Use 2 spaces for indentation.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
   Enabled: true
   Width: 2
-Style/IndentHash:
+Layout/IndentHash:
   Description: Checks the indentation of the first key in a hash literal.
   Enabled: true
   EnforcedStyle: special_inside_parentheses
@@ -247,7 +235,7 @@ Style/MethodDefParentheses:
   SupportedStyles:
   - require_parentheses
   - require_no_parentheses
-Style/MethodName:
+Naming/MethodName:
   Description: Use the configured style when naming methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
   Enabled: true
@@ -255,7 +243,7 @@ Style/MethodName:
   SupportedStyles:
   - snake_case
   - camelCase
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Description: Checks indentation of binary operations that span more than one line.
   Enabled: true
   EnforcedStyle: aligned
@@ -293,7 +281,7 @@ Style/PercentQLiterals:
   SupportedStyles:
   - lower_case_q
   - upper_case_q
-Style/PredicateName:
+Naming/PredicateName:
   Description: Check the names of predicate methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
   Enabled: true
@@ -370,11 +358,11 @@ Style/StringLiteralsInInterpolation:
   SupportedStyles:
   - single_quotes
   - double_quotes
-Style/SpaceAroundBlockParameters:
+Layout/SpaceAroundBlockParameters:
   Description: Checks the spacing inside and after block parameters pipes.
   Enabled: true
   EnforcedStyleInsidePipes: no_space
-Style/SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   Description: Checks that the equals signs in parameter default assignments have
     or don't have surrounding space depending on configuration.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-around-equals
@@ -383,14 +371,14 @@ Style/SpaceAroundEqualsInParameterDefault:
   SupportedStyles:
   - space
   - no_space
-Style/SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Description: Checks that the left block brace has or doesn't have space before it.
   Enabled: true
   EnforcedStyle: space
   SupportedStyles:
   - space
   - no_space
-Style/SpaceInsideBlockBraces:
+Layout/SpaceInsideBlockBraces:
   Description: Checks that block braces have or don't have surrounding space. For
     blocks taking parameters, checks that the left brace has or doesn't have trailing
     space.
@@ -401,7 +389,7 @@ Style/SpaceInsideBlockBraces:
   - no_space
   EnforcedStyleForEmptyBraces: no_space
   SpaceBeforeBlockParameters: true
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Description: Use spaces inside hash literal braces - or don't.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
@@ -415,7 +403,7 @@ Style/SymbolProc:
   Enabled: true
   IgnoredMethods:
   - respond_to
-Style/TrailingBlankLines:
+Layout/TrailingBlankLines:
   Description: Checks trailing blank lines and final newline.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#newline-eof
   Enabled: true
@@ -423,7 +411,9 @@ Style/TrailingBlankLines:
   SupportedStyles:
   - final_newline
   - final_blank_line
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingCommaInArguments:
   Enabled: true
@@ -452,7 +442,7 @@ Style/TrivialAccessors:
   - to_str
   - to_s
   - to_sym
-Style/VariableName:
+Naming/VariableName:
   Description: Use the configured style when naming variables.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
   Enabled: true
@@ -464,7 +454,6 @@ Style/WhileUntilModifier:
   Description: Favor modifier while/until usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier
   Enabled: false
-  MaxLineLength: 80
 Style/WordArray:
   Description: Use %w or %W for arrays of words.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-w
@@ -542,11 +531,11 @@ Lint/AssignmentInCondition:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
   Enabled: false
   AllowSafeAssignment: true
-Lint/EndAlignment:
+Layout/EndAlignment:
   Description: Align ends correctly.
   Enabled: true
   EnforcedStyleAlignWith: keyword
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   Description: Align ends corresponding to defs correctly.
   Enabled: true
   EnforcedStyleAlignWith: start_of_line
@@ -561,17 +550,17 @@ Style/SymbolArray:
   Description: Use %i or %I for arrays of symbols.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-i
   Enabled: false
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Description: Do not use unnecessary spacing.
   Enabled: true
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 Style/Alias:
   Description: Use alias_method instead of alias.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
   Enabled: false
-Style/AlignArray:
+Layout/AlignArray:
   Description: Align the elements of an array literal if they span more than one line.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays
   Enabled: true
@@ -583,7 +572,7 @@ Style/AsciiComments:
   Description: Use only ascii symbols in comments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-comments
   Enabled: false
-Style/AsciiIdentifiers:
+Naming/AsciiIdentifiers:
   Description: Use only ascii symbols in identifiers.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-identifiers
   Enabled: false
@@ -599,7 +588,7 @@ Style/BlockComments:
   Description: Do not use block comments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-block-comments
   Enabled: true
-Style/BlockEndNewline:
+Layout/BlockEndNewline:
   Description: Put end statement of multiline block on its own line.
   Enabled: true
 # Style/Blocks:
@@ -615,7 +604,7 @@ Style/CharacterLiteral:
   Description: Checks for uses of character literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-character-literals
   Enabled: false
-Style/ClassAndModuleCamelCase:
+Naming/ClassAndModuleCamelCase:
   Description: Use CamelCase for classes and modules.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#camelcase-classes
   Enabled: true
@@ -631,10 +620,10 @@ Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#double-colons
   Enabled: false
-Style/CommentIndentation:
+Layout/CommentIndentation:
   Description: Indentation of comments.
   Enabled: true
-Style/ConstantName:
+Naming/ConstantName:
   Description: Constants should use SCREAMING_SNAKE_CASE.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#screaming-snake-case
   Enabled: true
@@ -652,19 +641,19 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Description: Prefer `each_with_object` over `inject` or `reduce`.
   Enabled: false
-Style/ElseAlignment:
+Layout/ElseAlignment:
   Description: Align elses and elsifs correctly.
   Enabled: true
 Style/EmptyElse:
   Description: Avoid empty else-clauses.
   Enabled: true
-Style/EmptyLines:
+Layout/EmptyLines:
   Description: Don't use several empty lines in a row.
   Enabled: true
-Style/EmptyLinesAroundAccessModifier:
+Layout/EmptyLinesAroundAccessModifier:
   Description: Keep blank lines around access modifiers.
   Enabled: true
-Style/EmptyLinesAroundMethodBody:
+Layout/EmptyLinesAroundMethodBody:
   Description: Keeps track of empty lines around method bodies.
   Enabled: true
 Style/EmptyLiteral:
@@ -675,7 +664,7 @@ Style/EndBlock:
   Description: Avoid the use of END blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-END-blocks
   Enabled: true
-Style/EndOfLine:
+Layout/EndOfLine:
   Description: Use Unix-style line endings.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
   Enabled: true
@@ -691,10 +680,10 @@ Style/IfWithSemicolon:
   Description: Do not use if x; .... Use the ternary operator instead.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs
   Enabled: false
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   Description: Keep indentation straight.
   Enabled: true
-Style/IndentArray:
+Layout/IndentArray:
   Description: Checks the indentation of the first element in an array literal.
   Enabled: true
 Style/InfiniteLoop:
@@ -705,7 +694,7 @@ Style/Lambda:
   Description: Use the new lambda literal syntax for single-line blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#lambda-multi-line
   Enabled: false
-Style/LeadingCommentSpace:
+Layout/LeadingCommentSpace:
   Description: Comments should start with a space.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-space
   Enabled: true
@@ -725,7 +714,7 @@ Style/MultilineBlockChain:
   Description: Avoid multi-line chains of blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
   Enabled: true
-Style/MultilineBlockLayout:
+Layout/MultilineBlockLayout:
   Description: Ensures newlines after multiline block do statements.
   Enabled: true
 Style/MultilineIfThen:
@@ -760,7 +749,7 @@ Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
   Enabled: false
-Style/OpMethod:
+Naming/BinaryOperatorParameterName:
   Description: When defining binary operators, name the argument other.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#other-arg
   Enabled: false
@@ -793,55 +782,51 @@ Style/SelfAssignment:
     used.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
   Enabled: false
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Description: Checks that exactly one space is used between a method name and the
     first argument for method calls without parentheses.
   Enabled: true
-Style/SpaceAfterColon:
+Layout/SpaceAfterColon:
   Description: Use spaces after colons.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
-Style/SpaceAfterComma:
+Layout/SpaceAfterComma:
   Description: Use spaces after commas.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
-Style/SpaceAroundKeyword:
+Layout/SpaceAroundKeyword:
   Enabled: true
-Style/SpaceAfterMethodName:
+Layout/SpaceAfterMethodName:
   Description: Do not put a space between a method name and the opening parenthesis
     in a method definition.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
   Enabled: true
-Style/SpaceAfterNot:
+Layout/SpaceAfterNot:
   Description: Tracks redundant space after the ! operator.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-bang
   Enabled: true
-Style/SpaceAfterSemicolon:
+Layout/SpaceAfterSemicolon:
   Description: Use spaces after semicolons.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
-Style/SpaceBeforeComma:
+Layout/SpaceBeforeComma:
   Description: No spaces before commas.
   Enabled: true
-Style/SpaceBeforeComment:
+Layout/SpaceBeforeComment:
   Description: Checks for missing space between code and a comment on the same line.
   Enabled: true
-Style/SpaceBeforeSemicolon:
+Layout/SpaceBeforeSemicolon:
   Description: No spaces before semicolons.
   Enabled: true
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Description: Use spaces around operators.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
-Style/SpaceInsideBrackets:
-  Description: No spaces after [ or before ].
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
-  Enabled: true
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Description: No spaces after ( or before ).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
   Enabled: true
-Style/SpaceInsideRangeLiteral:
+Layout/SpaceInsideRangeLiteral:
   Description: No spaces inside range literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals
   Enabled: true
@@ -853,11 +838,11 @@ Style/StructInheritance:
   Description: Checks for inheritance from Struct.new.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new
   Enabled: true
-Style/Tab:
+Layout/Tab:
   Description: No hard tabs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
   Enabled: true
-Style/TrailingWhitespace:
+Layout/TrailingWhitespace:
   Description: Avoid trailing whitespace.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace
   Enabled: true
@@ -900,10 +885,10 @@ Lint/AmbiguousRegexpLiteral:
   Description: Checks for ambiguous regexp literals in the first argument of a method
     invocation without parenthesis.
   Enabled: false
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   Description: Align block ends correctly.
   Enabled: true
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Description: Checks for condition placed in a confusing position relative to the
     keyword.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
@@ -939,13 +924,6 @@ Security/Eval:
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
-  Enabled: false
-Lint/InvalidCharacterLiteral:
-  Description: Checks for invalid character literals with a non-escaped whitespace
-    character.
-  Enabled: false
-Lint/LiteralInCondition:
-  Description: Checks of literals used in conditions.
   Enabled: false
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in tmuxinator.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rubocop/rake_task"
 require "rspec/core/rake_task"

--- a/bin/tmuxinator
+++ b/bin/tmuxinator
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-$:.unshift File.expand_path("../../lib/", __FILE__)
+# frozen_string_literal: true
+
+$:.unshift File.expand_path("../lib", __dir__)
 
 require "thor"
 require "tmuxinator"

--- a/lib/tmuxinator.rb
+++ b/lib/tmuxinator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erubi"
 require "fileutils"
 require "shellwords"

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "open3"
 
 module Tmuxinator
@@ -193,7 +195,7 @@ module Tmuxinator
 
         begin
           Tmuxinator::Config.validate(options)
-        rescue => e
+        rescue StandardError => e
           exit! e.message
         end
       end

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   class Config
     LOCAL_DEFAULTS = ["./.tmuxinator.yml", "./.tmuxinator.yaml"].freeze
     NO_LOCAL_FILE_MSG =
-      "Project file at ./.tmuxinator.yml doesn't exist.".freeze
-    NO_PROJECT_FOUND_MSG = "Project could not be found.".freeze
+      "Project file at ./.tmuxinator.yml doesn't exist."
+    NO_PROJECT_FOUND_MSG = "Project could not be found."
     TMUX_MASTER_VERSION = Float::INFINITY
 
     class << self
@@ -12,6 +14,7 @@ module Tmuxinator
         return environment if environment?
         return xdg if xdg?
         return home if home?
+
         # No project directory specified or existent, default to XDG:
         FileUtils::mkdir_p(xdg)
         xdg
@@ -40,6 +43,7 @@ module Tmuxinator
       def environment
         environment = ENV["TMUXINATOR_CONFIG"]
         return "" if environment.to_s.empty? # variable is unset (nil) or blank
+
         FileUtils::mkdir_p(environment) unless File.directory?(environment)
         environment
       end
@@ -83,6 +87,7 @@ module Tmuxinator
       def exist?(name: nil, path: nil)
         return File.exist?(path) if path
         return File.exist?(project(name)) if name
+
         false
       end
 
@@ -147,18 +152,21 @@ module Tmuxinator
         unless exist?(path: project_config)
           raise "Project config (#{project_config}) doesn't exist."
         end
+
         true
       end
 
       def valid_local_project?(name)
         return false if name
         raise NO_LOCAL_FILE_MSG unless local?
+
         true
       end
 
       def valid_standard_project?(name)
         return false unless name
         raise "Project #{name} doesn't exist." unless exist?(name: name)
+
         true
       end
 
@@ -197,6 +205,7 @@ module Tmuxinator
       # recursively searching 'directory'
       def project_in(directory, name)
         return nil if String(directory).empty?
+
         projects = Dir.glob("#{directory}/**/*.{yml,yaml}").sort
         projects.detect { |project| File.basename(project, ".*") == name }
       end

--- a/lib/tmuxinator/deprecations.rb
+++ b/lib/tmuxinator/deprecations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   module Deprecations
     def rvm?

--- a/lib/tmuxinator/doctor.rb
+++ b/lib/tmuxinator/doctor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   class Doctor
     class << self

--- a/lib/tmuxinator/hooks.rb
+++ b/lib/tmuxinator/hooks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   module Hooks
     module_function

--- a/lib/tmuxinator/hooks/project.rb
+++ b/lib/tmuxinator/hooks/project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   module Hooks
     module Project
@@ -37,6 +39,6 @@ module Tmuxinator
         # this method can only be used from inside Tmuxinator::Project
         Tmuxinator::Hooks.commands_from self, "on_project_stop"
       end
-    end # End Project
-  end # End Hooks
-end # End Tmuxinator
+    end
+  end
+end

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   class Pane
     attr_reader :commands, :project, :index, :tab, :title
@@ -61,12 +63,12 @@ module Tmuxinator
 
     private
 
-    def _send_target(e)
-      _send_keys(tmux_window_and_pane_target, e)
+    def _send_target(keys)
+      _send_keys(tmux_window_and_pane_target, keys)
     end
 
-    def _send_keys(t, e)
-      "#{project.tmux} send-keys -t #{t} #{e} C-m"
+    def _send_keys(target, keys)
+      "#{project.tmux} send-keys -t #{target} #{keys} C-m"
     end
 
     def _set_title(title)

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   class Project
     include Tmuxinator::Util
@@ -47,8 +49,8 @@ module Tmuxinator
 
         content = render_template(path, binding)
         YAML.safe_load(content, aliases: true)
-      rescue SyntaxError, StandardError => error
-        raise "Failed to parse config file: #{error.message}"
+             rescue SyntaxError, StandardError => error
+               raise "Failed to parse config file: #{error.message}"
       end
 
       new(yaml, options)
@@ -71,6 +73,7 @@ module Tmuxinator
         unless windows?
       raise "Your project file didn't specify a 'project_name'" \
         unless name?
+
       self
     end
 
@@ -237,8 +240,8 @@ module Tmuxinator
       !name.nil?
     end
 
-    def window(i)
-      "#{name}:#{i}"
+    def window(index)
+      "#{name}:#{index}"
     end
 
     def send_pane_command(cmd, window_index, _pane_index)
@@ -383,9 +386,10 @@ module Tmuxinator
     def extract_tmux_config
       options_hash = {}
 
-      options_string = `#{show_tmux_options}`
-      options_string.encode!("UTF-8", invalid: :replace)
-      options_string.split("\n").map do |entry|
+      `#{show_tmux_options}`.
+        encode("UTF-8", invalid: :replace).
+        split("\n").
+        map do |entry|
         key, value = entry.split("\s")
         options_hash[key] = value
         options_hash

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   module TmuxVersion
     SUPPORTED_TMUX_VERSIONS = [
@@ -29,7 +31,7 @@ module Tmuxinator
       1.6,
       1.5,
     ].freeze
-    UNSUPPORTED_VERSION_MSG = <<-MSG.freeze
+    UNSUPPORTED_VERSION_MSG = <<-MSG
     WARNING: You are running tmuxinator with an unsupported version of tmux.
     Please consider using a supported version:
     (#{SUPPORTED_TMUX_VERSIONS.join(', ')})

--- a/lib/tmuxinator/util.rb
+++ b/lib/tmuxinator/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   module Util
     include Thor::Actions

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
-  VERSION = "3.1.2".freeze
+  VERSION = "3.1.2"
 end

--- a/lib/tmuxinator/wemux_support.rb
+++ b/lib/tmuxinator/wemux_support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   module WemuxSupport
     def render

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tmuxinator
   class Window
     include Tmuxinator::Util

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def yaml_load(file)
   YAML.safe_load(File.read(File.expand_path(file)))
 end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::Cli do
@@ -26,7 +28,7 @@ describe Tmuxinator::Cli do
 
   subject(:cli) { described_class }
 
-  let(:fixtures_dir) { File.expand_path("../../../fixtures/", __FILE__) }
+  let(:fixtures_dir) { File.expand_path("../../fixtures", __dir__) }
   let(:project) { FactoryBot.build(:project) }
   let(:project_config) do
     File.join(fixtures_dir, "sample_with_project_config.yml")
@@ -952,7 +954,7 @@ describe Tmuxinator::Cli do
     let(:name) { "sample" }
     let(:custom_name) { nil }
     let(:cli_options) { {} }
-    let(:path) { File.expand_path("../../../fixtures", __FILE__) }
+    let(:path) { File.expand_path("../../fixtures", __dir__) }
 
     shared_examples_for :a_proper_project do
       it "should create a valid project" do

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::Config do
-  let(:fixtures_dir) { File.expand_path("../../../fixtures/", __FILE__) }
+  let(:fixtures_dir) { File.expand_path("../../fixtures", __dir__) }
   let(:xdg_config_dir) { "#{fixtures_dir}/xdg-tmuxinator" }
   let(:home_config_dir) { "#{fixtures_dir}/dot-tmuxinator" }
 
@@ -184,25 +186,25 @@ describe Tmuxinator::Config do
     end
 
     version_mapping = {
-      "0.8"      => 0.8,
-      "1.0"      => 1.0,
-      "1.9"      => 1.9,
-      "1.9a"     => 1.9,
-      "2.4"      => 2.4,
-      "2.9a"     => 2.9,
-      "3.0-rc5"  => 3.0,
+      "0.8" => 0.8,
+      "1.0" => 1.0,
+      "1.9" => 1.9,
+      "1.9a" => 1.9,
+      "2.4" => 2.4,
+      "2.9a" => 2.9,
+      "3.0-rc5" => 3.0,
       "next-3.1" => 3.1,
-      "master"   => Float::INFINITY,
+      "master" => Float::INFINITY,
       # Failsafes
-      "foobar"   => 0.0,
-      "-123-"    => 123.0,
-      "5935"     => 5935.0,
-      ""         => 0.0,
-      "!@#^%"    => 0.0,
-      "2.9ä"     => 2.9,
-      "v3.5"     => 3.5,
-      "v3.12.0"  => 3.12,
-      "v3.12.5"  => 3.12
+      "foobar" => 0.0,
+      "-123-" => 123.0,
+      "5935" => 5935.0,
+      "" => 0.0,
+      "!@#^%" => 0.0,
+      "2.9ä" => 2.9,
+      "v3.5" => 3.5,
+      "v3.12.0" => 3.12,
+      "v3.12.5" => 3.12
     }.freeze
 
     version_mapping.each do |string_version, parsed_numeric_version|

--- a/spec/lib/tmuxinator/doctor_spec.rb
+++ b/spec/lib/tmuxinator/doctor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::Doctor do

--- a/spec/lib/tmuxinator/hooks/project_spec.rb
+++ b/spec/lib/tmuxinator/hooks/project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 shared_examples_for "a project hook" do

--- a/spec/lib/tmuxinator/hooks_spec.rb
+++ b/spec/lib/tmuxinator/hooks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::Hooks do

--- a/spec/lib/tmuxinator/pane_spec.rb
+++ b/spec/lib/tmuxinator/pane_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::Pane do

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::Project do
@@ -589,7 +591,7 @@ describe Tmuxinator::Project do
   end
 
   describe "::load" do
-    let(:path) { File.expand_path("../../../fixtures/sample.yml", __FILE__) }
+    let(:path) { File.expand_path("../../fixtures/sample.yml", __dir__) }
     let(:options) { {} }
 
     it "should raise if the project file doesn't parse" do
@@ -691,9 +693,11 @@ describe Tmuxinator::Project do
       before { project.yaml["pane_title_format"] = nil }
 
       it "configures a default format" do
+        # rubocop:disable Lint/InterpolationCheck
         expect(project.tmux_set_pane_title_format).to eq(
           'tmux set pane-border-format "#{pane_index}: #{pane_title}"'
         )
+        # rubocop:enable Lint/InterpolationCheck
       end
     end
 

--- a/spec/lib/tmuxinator/util_spec.rb
+++ b/spec/lib/tmuxinator/util_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::Util do

--- a/spec/lib/tmuxinator/wemux_support_spec.rb
+++ b/spec/lib/tmuxinator/wemux_support_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::WemuxSupport do

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Tmuxinator::Window do

--- a/spec/matchers/pane_matcher.rb
+++ b/spec/matchers/pane_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.alias_matcher :be_a_pane, :a_pane
 RSpec::Matchers.define :a_pane do
   attr_reader :commands

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coveralls"
 require "pry"
 require "simplecov"
@@ -39,7 +41,7 @@ def capture_io
 
   yield
 
-  return captured_stdout.string, captured_stderr.string
+  [captured_stdout.string, captured_stderr.string]
 ensure
   $stdout = orig_stdout
   $stderr = orig_stderr

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -1,6 +1,7 @@
 # coding: utf-8
+# frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "tmuxinator/version"
 

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry", "~> 0.10"
   s.add_development_dependency "rake", "~> 12.3.3"
   s.add_development_dependency "rspec", "~> 3.3"
-  s.add_development_dependency "rubocop", "~> 0.48.1"
+  s.add_development_dependency "rubocop", "~> 0.61.1"
   s.add_development_dependency "simplecov", "~> 0.16"
 
   # quiet "Gem.gunzip is deprecated" deprecation warning caused by rubocop


### PR DESCRIPTION
This PR is mostly to demonstrate the issue solved by https://github.com/tmuxinator/tmuxinator/pull/889

#### For further discussion

It's sort of unclear which versions of Ruby we want to test against at the moment. Based on the [ruby maintenance schedule](https://www.ruby-lang.org/en/downloads/branches/), Ruby < 3.0 was end of life as of 2023-03-31.

I'm open to the idea of cleaning up the test matrix and removing Ruby 2 support for tmuxinator.

Ruby 3.0 is also going end of life quite soon, 2024-03-31. How long should we continue testing with it after EOL?

Should we also maybe test against Ruby 3.1?

We're also testing against literally all versions of tmux since 1.5.
Would it make sense to at least collapse `3.1[,a,b,c]` to just `3.1c`?

Happy to report an issue for this discussion about which versions we want to support and test against.