### PR TITLE
chore: Bump tmuxinator to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 3.1.1
 ### Enhancements
 - add support for stop command without project name
 - add support for optional `--project-config` flag to `tmuxinator stop` command

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "3.1.0".freeze
+  VERSION = "3.1.1".freeze
 end


### PR DESCRIPTION
A motivating factor for release is new support for tmux 3.4.

I have never released tmuxinator before, but my plan is:

1. Merge this PR
2. Create a new release in GitHub, tagged with v3.1.1
3. Build and push the gem to rubygems using the `gem` command locally

Maybe it'd make sense to add a release workflow at some point, leveraging [this rubygems action](https://github.com/marketplace/actions/publish-to-rubygems).

## 3.1.1
### Enhancements
- add support for stop command without project name
- add support for optional `--project-config` flag to `tmuxinator stop` command
### Misc
- Fix typos and remove extra whitespace
- Set pane title if provided in config file
### tmux
- Add tmux 3.4 to test matrix
- Add tmux 3.4 to supported tmux versions list