### PR TITLE
Update tmux_version.rb

### DIFF
--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -1,7 +1,7 @@
 module Tmuxinator
   module TmuxVersion
     SUPPORTED_TMUX_VERSIONS = [
-      "3.4",
+      3.4,
       "3.3a",
       3.3,
       "3.2a",


### PR DESCRIPTION
3.4 should be treated as a float because it doesn't have a letter in the version number. 
Making it a string makes `supported?` return false instead of true for tmux v 3.4
![image (8)](https://github.com/tmuxinator/tmuxinator/assets/67331134/af50b77b-2215-4444-933b-2e30df806568)
