### PR TITLE
chore: Bump tmuxinator to 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+## 3.1.2
+### Fixes
+- Fix tmux 3.4 version in the supported versions list
+
 ## 3.1.1
 ### Enhancements
 - add support for stop command without project name

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,3 +1,3 @@
 module Tmuxinator
-  VERSION = "3.1.1".freeze
+  VERSION = "3.1.2".freeze
 end


### PR DESCRIPTION
## 3.1.2
### Fixes
- Fix tmux 3.4 version in the supported versions list