### PR TITLE
fix: Shellescape pane titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Fixes
+- Shell escape pane titles to fix multi word and special character titles
 
 ## 3.1.2
 ### Fixes

--- a/lib/tmuxinator/pane.rb
+++ b/lib/tmuxinator/pane.rb
@@ -7,7 +7,7 @@ module Tmuxinator
       @index = index
       @project = project
       @tab = tab
-      @title = title
+      @title = title.to_s.shellescape unless title.nil?
     end
 
     def tmux_window_and_pane_target

--- a/spec/lib/tmuxinator/pane_spec.rb
+++ b/spec/lib/tmuxinator/pane_spec.rb
@@ -10,7 +10,7 @@ describe Tmuxinator::Pane do
   let(:project) { double }
   let(:window) { double }
   let(:commands) { ["vim", "bash"] }
-  let(:title) { "test" }
+  let(:title) { "test (a test)" }
 
   before do
     allow(project).to receive(:name).and_return "foo"
@@ -39,7 +39,7 @@ describe Tmuxinator::Pane do
 
     it "sets pane title" do
       expect(subject.tmux_set_title).to eql(
-        "tmux select-pane -t foo:0.1 -T test"
+        "tmux select-pane -t foo:0.1 -T test\\ \\(a\\ test\\)"
       )
     end
   end


### PR DESCRIPTION
#### Problem
Pane titles are currently not shell escaped, so multi word titles or titles containing shell characters break, i.e.

```
$ mux pane-names
usage: select-pane [-DdeLlMmRUZ] [-T title] [-t target-pane]
sh: 36: Syntax error: "(" unexpected
```

Session and window names are already escaped in this way.

```
name: pane-names (a test! | let's find out)
root: ~/dev/sandbox

windows:
  - editor (and others):
      layout: tiled
      panes:
        - vim and things:
          - vim
        - mostly just docker (maybe compose):
          - docker ps
```

Fixes #900