### PR TITLE
Remove mux alias in Bash completion file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Fixes
 - Shell escape pane titles to fix multi word and special character titles
 - Replace exists? with exist? for Ruby >= 3.2
+### Misc
+- Remove `mux` alias from Fish and Bash completions
 
 ## 3.1.2
 ### Fixes

--- a/completion/tmuxinator.bash
+++ b/completion/tmuxinator.bash
@@ -19,5 +19,4 @@ _tmuxinator() {
     fi
 }
 
-complete -F _tmuxinator tmuxinator mux
-alias mux="tmuxinator"
+complete -F _tmuxinator tmuxinator

--- a/completion/tmuxinator.fish
+++ b/completion/tmuxinator.fish
@@ -20,5 +20,3 @@ complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_comman
 complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command open'      -a "(__fish_tmuxinator_program completions open)"
 complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command copy'      -a "(__fish_tmuxinator_program completions copy)"
 complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command delete'    -a "(__fish_tmuxinator_program completions delete)"
-
-abbr --add mux "tmuxinator"


### PR DESCRIPTION
Original PR from @hyperupcall: https://github.com/tmuxinator/tmuxinator/pull/880

It should be removed because:

Aliases in completion files are unconventional
This will conflict with user-defined aliases in unexpected and hard-to-debug ways
It is not consistent with completions for the other shells that we support (zsh)
Is confusing
Closes https://github.com/tmuxinator/tmuxinator/issues/868

---

I had to open this as a new PR because the CHANGELOG was outdated, and I didn't have push access to the original branch.