### PR TITLE
chore: Add Ruby 3.2, 3.1 to the test matrix; rm ruby < 3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '3.0.1'
-          - '2.7.3'
-          - '2.6.7'
+          - '3.3.0'
+          - '3.2.3'
+          - '3.1.4'
+          - '3.0.6'
         tmux_version:
           - '3.4'
           - '3.3a'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Replace exists? with exist? for Ruby >= 3.2
 ### Misc
 - Remove `mux` alias from Fish and Bash completions
+- Add Ruby 3.2, 3.1 to the test matrix; rm ruby < 3>
 
 ## 3.1.2
 ### Fixes


### PR DESCRIPTION
## Metadata

Some related discussion exists on this PR: https://github.com/tmuxinator/tmuxinator/pull/896

Ruby maintenance cycle: https://www.ruby-lang.org/en/downloads/branches/

<img width="623" alt="Screenshot 2024-03-31 at 15 09 22" src="https://github.com/tmuxinator/tmuxinator/assets/761923/cc32ee51-a5e5-4b0f-b1d9-7ddd718976b5">

## Problem

We aim to support currently maintained versions of Ruby, [from our Readme](https://github.com/tmuxinator/tmuxinator/blob/master/README.md?plain=1#L31):

> tmuxinator aims to be compatible with the currently maintained versions of Ruby

We're still testing against Ruby < 3, and we're not testing against more recent versions of Ruby.

## Solution

Update the test matrix to remove old versions and add new versions.