### PR TITLE
feat: Add support for tmuxinator append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Features
+- Add support for tmuxinator start --append
 
 ## 3.3.3
 ### Features

--- a/README.md
+++ b/README.md
@@ -398,6 +398,11 @@ Shows tmuxinator's version.
 tmuxinator version
 ```
 
+Append a project's windows to the current session (instead of creating a new session)
+```
+tmuxinator start [project] --append
+```
+
 ## Project Configuration Location
 
 Using environment variables, it's possible to define which directory

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -1,17 +1,19 @@
 #!<%= ENV["SHELL"] || "/bin/bash" %>
 
-# Clear rbenv variables before starting tmux
-unset RBENV_VERSION
-unset RBENV_DIR
+<%- if !append? -%>
+  # Clear rbenv variables before starting tmux
+  unset RBENV_VERSION
+  unset RBENV_DIR
 
-<%= tmux %> start-server;
+  <%= tmux %> start-server;
+<%- end -%>
 
 cd <%= root || "." %>
 
 # Run on_project_start command.
 <%= hook_on_project_start %>
 
-<%- if !tmux_has_session? name -%>
+<%- if append? || !tmux_has_session?(name) -%>
 
   # Run pre command.
   <%= pre %>
@@ -98,7 +100,7 @@ cd <%= root || "." %>
   <%= hook_on_project_restart %>
 <%- end -%>
 
-<%- if attach? -%>
+<%- if attach? && !append? -%>
   if [ -z "$TMUX" ]; then
     <%= tmux %> -u attach-session -t <%= name %>
   else

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -115,4 +115,12 @@ FactoryBot.define do
 
     initialize_with { Tmuxinator::Project.load(file) }
   end
+
+  factory :project_with_append, class: Tmuxinator::Project do
+    transient do
+      file { "spec/fixtures/sample.yml" }
+    end
+
+    initialize_with { Tmuxinator::Project.load(file, append: true) }
+  end
 end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -104,6 +104,17 @@ describe Tmuxinator::Cli do
             expect(instance).to receive(:start).with(*args)
             subject
           end
+
+          context "and the append option is passed" do
+            let(:args) { ["sample", "--append"] }
+
+            it "should call #start" do
+              instance = instance_double(cli)
+              expect(cli).to receive(:new).and_return(instance)
+              expect(instance).to receive(:start).with("sample", "--append")
+              subject
+            end
+          end
         end
 
         context "a thor command" do


### PR DESCRIPTION
## Metadata

Original PR from @flovilmart: https://github.com/tmuxinator/tmuxinator/pull/652

## Problem

Closes: https://github.com/tmuxinator/tmuxinator/issues/265

It often makes sense to want to add a tmuxinator project to an existing tmux session vs. creating a new session.

## Solution

Add a new option to append a project's windows to the current session instead of creating a new session.

```
tmuxinator start [project] --append
```

## Testing

I've covered the code additions with additional unit tests where the behavior changes when being called with `--append`.

### Relevant Scenarios

Using `--append` outside a tmux session results in an error.

```sh
$ (cd ~/dev/repos/tmuxinator; bundle exec tmuxinator start --append 908)
Cannot append to a session that does not exist
```

Test that `--append` captures the correct next window index by running it from sessions of various numbers of existing windows:

```sh
# From within tmux session "908"
$ (cd ~/dev/repos/tmuxinator; bundle exec tmuxinator start --append 908)

# Also try it across session names, like from a session named "test"
$ (cd ~/dev/repos/tmuxinator; bundle exec tmuxinator start --append 908)
```

The first example results in a tmux session with windows like this, where the "908" project has windows named `window1`, `window2`, `window3`. Note the window indexes as well:

<img width="722" alt="Screenshot 2025-03-16 at 12 35 14" src="https://github.com/user-attachments/assets/b7c42ade-a57d-4015-8209-8335ed108724" />

The second example shows appended windows of different names than the existing current session windows:

<img width="722" alt="Screenshot 2025-03-16 at 12 55 28" src="https://github.com/user-attachments/assets/0a39d828-59b0-475d-9f13-20e5ea8c5339" />

You can append as many times as you'd like until you hit limits with the number of tmux windows per session.

## Original Description / Commit Messages

Adds support for tmuxinator append

Adds ability to specify default loading behavior (start or append)

- Use start when not possible to append

nits

nits and improvements

refactor Cli::bootstrap (#1)

Adds reference to the new command

use say

cli: Adds tests for bootstraping with option set to append

adds tests for project window index

refactor to use start --append instead of append. improve config loading

reduce complexity of the start method

reduce complexity in cli.rb

void(commit)

extract get params

Update lib/tmuxinator/config.rb



Update lib/tmuxinator/project.rb



Update lib/tmuxinator/cli.rb