### PR TITLE
chore: Bump tmuxinator to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## 3.2.0
 ### Third-party Dependencies
 - Replace erubis with erubi
 - Upgrade rubocop to 0.61 for Ruby > 3.0 support

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.1.2"
+  VERSION = "3.2.0"
 end


### PR DESCRIPTION
## 3.2.0
### Third-party Dependencies
- Replace erubis with erubi
- Upgrade rubocop to 0.61 for Ruby > 3.0 support
### Enhancements
- Add configuration options for pane titles
### Fixes
- Shell escape pane titles to fix multi word and special character titles
- Replace exists? with exist? for Ruby >= 3.2
### Misc
- Remove `mux` alias from Fish and Bash completions
- Add Ruby 3.2, 3.1 to the test matrix; rm ruby < 3>