### PR TITLE
Fix pane title options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix pane title configuration options only applying to first window
 
 ## 3.2.0
 ### Third-party Dependencies

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -36,12 +36,9 @@ cd <%= root || "." %>
   <% if enable_pane_titles? %>
     <% if Tmuxinator::Config.version < 2.6 %>
   <%= pane_titles_not_supported_warning %>
-    <%- else -%>
-      <% if pane_title_position? && !pane_title_position_valid? %>
+    <% end %>
+    <% if pane_title_position? && !pane_title_position_valid? %>
   <%= pane_title_position_not_valid_warning %>
-      <% end %>
-  <%= tmux_set_pane_title_position %>
-  <%= tmux_set_pane_title_format %>
     <% end %>
   <% end %>
 
@@ -56,6 +53,12 @@ cd <%= root || "." %>
     <% if window.synchronize_before? %>
   <%= window.tmux_synchronize_panes %>
     <% end %>
+
+    <% if enable_pane_titles? && Tmuxinator::Config.version >= 2.6 %>
+  <%= tmux_set_pane_title_position(window.tmux_window_target) %>
+  <%= tmux_set_pane_title_format(window.tmux_window_target) %>
+    <% end %>
+
     <% unless window.panes? %>
       <% if window.project.pre_window %>
   <%= window.tmux_pre_window_command %>

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -341,19 +341,21 @@ module Tmuxinator
       yaml["enable_pane_titles"]
     end
 
-    def tmux_set_pane_title_position
+    def tmux_set_pane_title_position(tmux_window_target)
+      command = set_window_option(tmux_window_target)
       if pane_title_position? && pane_title_position_valid?
-        "#{tmux} set pane-border-status #{yaml['pane_title_position']}"
+        "#{command} pane-border-status #{yaml['pane_title_position']}"
       else
-        "#{tmux} set pane-border-status top"
+        "#{command} pane-border-status top"
       end
     end
 
-    def tmux_set_pane_title_format
+    def tmux_set_pane_title_format(tmux_window_target)
+      command = set_window_option(tmux_window_target)
       if pane_title_format?
-        "#{tmux} set pane-border-format \"#{yaml['pane_title_format']}\""
+        "#{command} pane-border-format \"#{yaml['pane_title_format']}\""
       else
-        "#{tmux} set pane-border-format \"\#{pane_index}: \#{pane_title}\""
+        "#{command} pane-border-format \"\#{pane_index}: \#{pane_title}\""
       end
     end
 
@@ -437,6 +439,10 @@ module Tmuxinator
       no_color = '\033[0m'
       msg = "WARNING: #{message}\n"
       "printf \"#{yellow}#{msg}#{no_color}\""
+    end
+
+    def set_window_option(tmux_window_target)
+      "#{tmux} set-window-option -t #{tmux_window_target}"
     end
   end
 end

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -663,8 +663,8 @@ describe Tmuxinator::Project do
       before { project.yaml["pane_title_position"] = nil }
 
       it "configures a default position of top" do
-        expect(project.tmux_set_pane_title_position).to eq(
-          "tmux set pane-border-status top"
+        expect(project.tmux_set_pane_title_position("x")).to eq(
+          "tmux set-window-option -t x pane-border-status top"
         )
       end
     end
@@ -673,8 +673,8 @@ describe Tmuxinator::Project do
       before { project.yaml["pane_title_position"] = "bottom" }
 
       it "configures a position of bottom" do
-        expect(project.tmux_set_pane_title_position).to eq(
-          "tmux set pane-border-status bottom"
+        expect(project.tmux_set_pane_title_position("x")).to eq(
+          "tmux set-window-option -t x pane-border-status bottom"
         )
       end
     end
@@ -683,8 +683,8 @@ describe Tmuxinator::Project do
       before { project.yaml["pane_title_position"] = "other" }
 
       it "configures the default position" do
-        expect(project.tmux_set_pane_title_position).to eq(
-          "tmux set pane-border-status top"
+        expect(project.tmux_set_pane_title_position("x")).to eq(
+          "tmux set-window-option -t x pane-border-status top"
         )
       end
     end
@@ -693,9 +693,10 @@ describe Tmuxinator::Project do
       before { project.yaml["pane_title_format"] = nil }
 
       it "configures a default format" do
-        expect(project.tmux_set_pane_title_format).to eq(
-          "tmux set pane-border-format \"\#{pane_index}: \#{pane_title}\""
-        )
+        resp = ""\
+          "tmux set-window-option -t x pane-border-format"\
+          " \"\#{pane_index}: \#{pane_title}\""
+        expect(project.tmux_set_pane_title_format("x")).to eq(resp)
       end
     end
 
@@ -703,8 +704,8 @@ describe Tmuxinator::Project do
       before { project.yaml["pane_title_format"] = " [ #T ] " }
 
       it "configures the provided format" do
-        expect(project.tmux_set_pane_title_format).to eq(
-          'tmux set pane-border-format " [ #T ] "'
+        expect(project.tmux_set_pane_title_format("x")).to eq(
+          'tmux set-window-option -t x pane-border-format " [ #T ] "'
         )
       end
     end


### PR DESCRIPTION
I did not do a very good job testing in #892, because the current implementation of `enable_pane_titles`, `pane_title_position`, and `pane_title_format` only sets the desired setting for the first window. I think I may have had a previous global configuration active which threw off my results.

This PR fixes those options to behave as expected, i.e., setting the options across the project.

As it turns out `tmux set pane-border-status top` only sets the option for a single window, i.e., the active one. For it to be set across a session without using the global `-g` flag, the command must target each window individually.
