### PR TITLE
Prioritize newer syntax if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Fix pane title configuration options only applying to first window
+- Use `tmux -c` if available to reduce spam
 
 ## 3.2.0
 ### Third-party Dependencies

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -21,9 +21,15 @@ cd <%= root || "." %>
 
   # Create the session and the first window. Manually switch to root
   # directory if required to support tmux < 1.9
-  TMUX= <%= tmux_new_session_command %>
   <% if windows.first.root? %>
+    <% if Tmuxinator::Config.version < 1.9 %>
+  TMUX= <%= tmux_new_session_command %>
   <%= windows.first.tmux_window_command_prefix %> <%= "cd #{windows.first.root}".shellescape %> C-m
+    <%- else -%>
+  TMUX= <%= tmux_new_session_command %> -c <%= windows.first.root.shellescape %>
+    <% end %>
+  <%- else -%>
+  TMUX= <%= tmux_new_session_command %>
   <% end %>
 
   <% if Tmuxinator::Config.version < 1.7 %>


### PR DESCRIPTION
Due to my investigation into #909 I have become keenly aware of the printouts tmuxinator may produce. One such printout is the `cd <root>` which gets sent to the first window in the project. What's more, this is not necessary with the quote-unquote modern (tmux >1.9 lol) syntax, where a starting directory can be provided directly to the `new-session` command.

This PR will take advantage of this syntax if available to reduce the excessive printouts.

N.B.: @akofink I'm starting to see why you wanted to drop the earlier versions of tmux.