### PR TITLE
chore: Bump tmuxinator to 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
-- Fix pane title configuration options only applying to first window
+
+## 3.2.1
+### Enhancements
 - Use `tmux -c` if available to reduce spam
+### Fixes
+- Fix pane title configuration options only applying to first window
 
 ## 3.2.0
 ### Third-party Dependencies

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end


### PR DESCRIPTION
## 3.2.1
### Enhancements
- Use `tmux -c` if available to reduce spam
### Fixes
- Fix pane title configuration options only applying to first window
