### PR TITLE
fix: Session current path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Fixes
+- Session path is project root, not first window root
 
 ## 3.2.1
 ### Enhancements

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -19,18 +19,7 @@ cd <%= root || "." %>
   # Run on_project_first_start command.
   <%= hook_on_project_first_start %>
 
-  # Create the session and the first window. Manually switch to root
-  # directory if required to support tmux < 1.9
-  <% if windows.first.root? %>
-    <% if Tmuxinator::Config.version < 1.9 %>
   TMUX= <%= tmux_new_session_command %>
-  <%= windows.first.tmux_window_command_prefix %> <%= "cd #{windows.first.root}".shellescape %> C-m
-    <%- else -%>
-  TMUX= <%= tmux_new_session_command %> -c <%= windows.first.root.shellescape %>
-    <% end %>
-  <%- else -%>
-  TMUX= <%= tmux_new_session_command %>
-  <% end %>
 
   <% if Tmuxinator::Config.version < 1.7 %>
   # Set the default path for versions prior to 1.7
@@ -48,8 +37,8 @@ cd <%= root || "." %>
     <% end %>
   <% end %>
 
-  # Create other windows.
-  <% windows.drop(1).each do |window| %>
+  # Create windows.
+  <% windows.each do |window| %>
   <%= window.tmux_new_window_command %>
   <% end %>
 

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -115,7 +115,7 @@ module Tmuxinator
 
     def tmux_new_window_command
       path = root? ? "#{Tmuxinator::Config.default_path_option} #{root}" : nil
-      "#{project.tmux} new-window #{path} -t #{tmux_window_target} #{tmux_window_name_option}"
+      "#{project.tmux} new-window #{path} -k -t #{tmux_window_target} #{tmux_window_name_option}"
     end
 
     def tmux_tiled_layout_command

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -354,7 +354,7 @@ describe Tmuxinator::Window do
 
     let(:window_part) { "new-window" }
     let(:name_part) { window.tmux_window_name_option }
-    let(:target_part) { "-t #{window.tmux_window_target}" }
+    let(:target_part) { "-k -t #{window.tmux_window_target}" }
     let(:path_part) { "#{path_option} #{project.root}" }
 
     let(:path_option) { "-c" }


### PR DESCRIPTION
## Problems being solved

We [attempted to leverage](https://github.com/tmuxinator/tmuxinator/pull/914) `tmux new-session [-c start-directory]` for tmux >= 1.9 instead of relying on `cd <start-directory>` before the `new-session` command, which by default uses the current working directory.

The tmux manpage for `new-session` allows configuring the first window name, but `-c` still applies to the session:

```
new-session [-AdDEP] [-c start-directory] [-F format] [-n window-name] [-s session-name] [-t group-name] [-x width] [-y height] [shell-command]
             (alias: new)
       Create a new session with name session-name.

       The new session is attached to the current terminal unless -d is given.  window-name and shell-command are the name
       of and shell command to execute in the initial window.  If -d is used, -x and -y specify the size of the initial
       window.
       ...
```

The PR that introduced `-c` for `new-session` used the first window's root, if it was defined, instead of the project's root.

Fixes #916 

## How the problems are being solved

Remove the `-c` option in `new-session` entirely to use the current working directory, set to the project root vs. the first window's root. This allows us to remove special handling for tmux < 1.9, which is when the option was added to `new-session` (it exists on `new-window` since before tmux 1.0).

Run the `new-window` command for all windows, including the first window, with `-c`, leveraging option `-k`:

```
if the target already exists an error is shown, unless the -k flag is used, in which case it is destroyed.
...
-c specifies the working directory in which the new window is created.
```

## How to test it

Use this config, copied from #916:

```yaml
name: 916
root: /tmp

windows:
  - dir2:
      root: /tmp/dir2
  - dir1:
      root: /tmp/dir1
```

`mux debug 916` output shows correct `-c` paths:

```sh
  ...
  cd /tmp
  ...
  TMUX= tmux new-session -d -s 916 -n a

  # Create windows.
  tmux new-window -c /tmp/dir2 -k -t 916:1 -n dir2
  tmux new-window -c /tmp/dir1 -k -t 916:2 -n dir1
  ...
```