### PR TITLE
feat: Detect relative window root, join with project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Enhancements
+- Detect relative window root, join with project root
 ### Fixes
 - Session path is project root, not first window root
 ### Misc

--- a/lib/tmuxinator/window.rb
+++ b/lib/tmuxinator/window.rb
@@ -36,12 +36,16 @@ module Tmuxinator
       yaml["synchronize"] || false
     end
 
+    # The expanded, joined window root path
+    # Relative paths are joined to the project root
     def root
-      _yaml_root || _project_root
+      return _project_root unless _yaml_root
+
+      File.expand_path(_yaml_root, _project_root).shellescape
     end
 
     def _yaml_root
-      File.expand_path(yaml["root"]).shellescape if yaml["root"]
+      yaml["root"]
     end
 
     def _project_root

--- a/spec/lib/tmuxinator/window_spec.rb
+++ b/spec/lib/tmuxinator/window_spec.rb
@@ -7,6 +7,8 @@ describe Tmuxinator::Window do
   let(:panes) { ["vim", nil, "top"] }
   let(:window_name) { "editor" }
   let(:synchronize) { false }
+  let(:root) {}
+  let(:root?) { root }
   let(:yaml) do
     {
       window_name => {
@@ -16,27 +18,14 @@ describe Tmuxinator::Window do
         ],
         "synchronize" => synchronize,
         "layout" => "main-vertical",
-        "panes" => panes
-      }
-    }
-  end
-  let(:yaml_root) do
-    {
-      "editor" => {
-        "root" => "/project/override",
-        "root?" => true,
-        "pre" => [
-          "echo 'I get run in each pane.  Before each pane command!'",
-          nil
-        ],
-        "layout" => "main-vertical",
-        "panes" => panes
+        "panes" => panes,
+        "root" => root,
+        "root?" => root?,
       }
     }
   end
 
   let(:window) { described_class.new(yaml, 0, project) }
-  let(:window_root) { described_class.new(yaml_root, 0, project) }
 
   shared_context "window command context" do
     let(:project) { double(:project) }
@@ -81,9 +70,19 @@ describe Tmuxinator::Window do
       end
     end
 
-    context "with window root" do
+    context "with absolute window root" do
+      let(:root) { "/project/override" }
+
       it "gets the window root" do
-        expect(window_root.root).to include("/project/override")
+        expect(window.root).to include("/project/override")
+      end
+    end
+
+    context "with relative window root" do
+      let(:root) { "relative" }
+
+      it "joins the project root" do
+        expect(window.root).to include("/project/tmuxinator/relative")
       end
     end
   end


### PR DESCRIPTION
## Problem

Relative window root paths are relative to the current working directory (CWD), something that is likely an unintentional side effect of using `File.expand_path(...)`, which is aware of the CWD:

```sh
$ (cd /tmp; ruby -e "puts File.expand_path('')")
/tmp
```

## Solution

Rely on [`File.expand_path(file_name [, dir_string] )`](https://ruby-doc.org/core-2.6/File.html#method-c-expand_path), leveraging `dir_string` so that window root paths can be relative to the project root, absolute, or use `~/...` for home paths.

Note that you can easily create relative tmuxinator configs by not setting the project root.

It's possible someone is using tmuxinator to start tmux windows relative to their current working directory, while also setting their project root. I believe this is likely very few users. Furthermore, no one seems to have downvoted #410.  If anyone wants to create a window config that follows their CWD, but a project config with a `root`, they can use `<%= ENV['PWD'] %>`.

Fixes #410 

## How to test

Use the project file below.
Verify that each of the window root paths match the absolute path in the corresponding comment.

```yaml
name: 410
root: /tmp/project

windows:
  - relative: # /tmp/project/relative
      root: relative
  - dotrelative: # /tmp/project/relative
      root: ./relative
  - absolute: # /tmp/project/absolute
      root: /tmp/project/absolute
  - home: # $HOME/tmp
      root: ~/tmp
  - cwdabsolute: # $PWD/lib
      root: <%= ENV['PWD'] %>/lib
```

If you run `tmuxinator debug 410`, you should see the paths passed into `new-window` with `-c`:

```sh
# Create windows.
tmux new-window -c /tmp/project/relative -k -t 410:1 -n relative
tmux new-window -c /tmp/project/relative -k -t 410:2 -n dotrelative
tmux new-window -c /tmp/project/absolute -k -t 410:3 -n absolute
tmux new-window -c /home/akofink/tmp -k -t 410:4 -n home
tmux new-window -c /home/akofink/dev/repos/tmuxinator/lib -k -t 410:5 -n cwdabsolute
```