### PR TITLE
chore: Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+### Metadata
+
+Links to relevant docs, related PRs or issues, etc.
+
+### Problem / Motivation
+
+Describe what the problem is or why the change is needed
+
+### Solution
+
+- [ ] CHANGELOG entry is added for code changes
+
+Describe how you are solving the problem
+
+### Testing
+
+Describe any interesting automated test changes
+
+Provide a test project yaml file, if relevant
+
+Provide any additional reproducing steps
+
+Show expected output / screenshot


### PR DESCRIPTION
### Metadata

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

### Problem / Motivation

Contributors and reviewers both might benefit from a bit more structure when submitting code changes

### Solution

- [x] CHANGELOG entry is added for code changes

Add a PR template. I'm using it for this PR right now :)

### Testing

N/A