### PR TITLE
chore: Bump tmuxinator to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## 3.3.0
 ### Enhancements
 - Detect relative window root, join with project root
 ### Fixes

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.2.1"
+  VERSION = "3.3.0"
 end


### PR DESCRIPTION
## 3.3.0
### Enhancements
- Detect relative window root, join with project root
### Fixes
- Session path is project root, not first window root
### Misc
- Unpin activesupport as a development depenedency