### PR TITLE
chore: Update CI ruby versions matrix, drop 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '3.3.0'
-          - '3.2.3'
-          - '3.1.4'
-          - '3.0.6'
+          - '3.3.3'
+          - '3.2.4'
+          - '3.1.6'
         tmux_version:
           - '3.4'
           - '3.3a'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Misc
+- Update Ruby 3.1, 3.2, 3.3 in the test matrix; rm ruby 3.0
 
 ## 3.3.0
 ### Enhancements


### PR DESCRIPTION
### Metadata

https://www.ruby-lang.org/en/downloads/branches/

### Problem / Motivation

We want to test against the most recent patch version of each supported Ruby

### Solution

- [x] CHANGELOG entry is added for code changes

Remove 3.0, bump patch versions of 3.1, 3.2, and 3.3

### Testing

In the CI pipeline