### PR TITLE
fix: Don't unset TMUX variable for new-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### tmux
 - Add tmux 3.5 to test matrix
 - Add tmux 3.5 to supported tmux versions list
+### Fixes
+- Don't unset TMUX env variable for new-session
 
 ## 3.3.0
 ### Enhancements

--- a/lib/tmuxinator/assets/template.erb
+++ b/lib/tmuxinator/assets/template.erb
@@ -19,7 +19,7 @@ cd <%= root || "." %>
   # Run on_project_first_start command.
   <%= hook_on_project_first_start %>
 
-  TMUX= <%= tmux_new_session_command %>
+  <%= tmux_new_session_command %>
 
   <% if Tmuxinator::Config.version < 1.7 %>
   # Set the default path for versions prior to 1.7


### PR DESCRIPTION
### Metadata

fixes #924

Links to relevant docs, related PRs or issues, etc.

### Problem / Motivation

The [TMUX env variable contains the server socket path](https://github.com/tmux/tmux/blob/master/environ.c#L271). If the current server isn't using the default socket path, it errors finding the session:

```
$  tmuxinator start sample
can't find session: sample
can't find session: sample
can't find session: sample
```

Users of tmuxinator likely don't want to start a new tmux server.

### Solution

- [x] CHANGELOG entry is added for code changes

Remove the `TMUX= ` from the template before `new-session`

### Testing

See the difference in the output with `tmuxinator debug <project>`
