### PR TITLE
chore: Bump tmuxinator to v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## 3.3.1
 ### Misc
 - Update Ruby 3.1, 3.2, 3.3 in the test matrix; rm ruby 3.0
 ### tmux

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.3.0"
+  VERSION = "3.3.1"
 end


### PR DESCRIPTION
## 3.3.1
### Misc
- Update Ruby 3.1, 3.2, 3.3 in the test matrix; rm ruby 3.0
### tmux
- Add tmux 3.5 to test matrix
- Add tmux 3.5 to supported tmux versions list
### Fixes
- Don't unset TMUX env variable for new-session