### PR TITLE
chore: Add support for tmux 3.5a

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '3.3.3'
-          - '3.2.4'
+          - '3.3.5'
+          - '3.2.5'
           - '3.1.6'
         tmux_version:
+          - '3.5a'
           - '3.5'
           - '3.4'
           - '3.3a'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased
+### Misc
+- Bump patch versions of Ruby 3.1, 3.2, 3.3 in the test matrix
+### tmux
+- Add tmux 3.5a to test matrix
 
 ## 3.3.1
 ### Misc

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -3,6 +3,7 @@
 module Tmuxinator
   module TmuxVersion
     SUPPORTED_TMUX_VERSIONS = [
+      "3.5a",
       3.5,
       3.4,
       "3.3a",


### PR DESCRIPTION
### Metadata

https://github.com/tmux/tmux/releases/tag/3.5a

### Problem / Motivation

Tmux released a bug fix version, 3.5a

### Solution

- [x] CHANGELOG entry is added for code changes

Add this new version to the list of supported tmux versions

Update the test matrix with tmux 3.5a

Bump patch versions of ruby in the test matrix

### Testing

Existing CI tests, now testing against tmux 3.5a.
