### PR TITLE
feat: Add -a option to list active projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Bump patch versions of Ruby 3.1, 3.2, 3.3 in the test matrix
 ### tmux
 - Add tmux 3.5a to test matrix
+### Features
+- Add active (-a) option to tmuxinator list
 
 ## 3.3.1
 ### Misc

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -391,13 +391,17 @@ module Tmuxinator
     method_option :newline, type: :boolean,
                             aliases: ["-n"],
                             desc: "Force output to be one entry per line."
+    method_option :active, type: :boolean,
+                           aliases: ["-a"],
+                           desc: "Filter output by active project sessions."
 
     def list
       say "tmuxinator projects:"
+      configs = Tmuxinator::Config.configs(active: options[:active])
       if options[:newline]
-        say Tmuxinator::Config.configs.join("\n")
+        say configs.join("\n")
       else
-        print_in_columns Tmuxinator::Config.configs
+        print_in_columns configs
       end
     end
 

--- a/lib/tmuxinator/config.rb
+++ b/lib/tmuxinator/config.rb
@@ -126,13 +126,33 @@ module Tmuxinator
         asset_path "wemux_template.erb"
       end
 
-      # Sorted list of all .yml files, including duplicates
-      def configs
-        directories.map do |directory|
+      # List of all active tmux sessions
+      def active_sessions
+        `tmux list-sessions -F "#S"`.split("\n")
+      end
+
+      # Sorted list of all project .yml file basenames, including duplicates
+      #
+      # @param active filter configs by active project sessions
+      # @return [Array<String>] list of project names
+      def configs(active: nil)
+        configs = config_file_basenames
+
+        if active == true
+          configs &= active_sessions
+        elsif active == false
+          configs -= active_sessions
+        end
+
+        configs
+      end
+
+      def config_file_basenames
+        directories.flat_map do |directory|
           Dir["#{directory}/**/*.yml"].map do |path|
             path.gsub("#{directory}/", "").gsub(".yml", "")
           end
-        end.flatten.sort
+        end.sort
       end
 
       # Existent directories which may contain project files

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -845,6 +845,14 @@ describe Tmuxinator::Cli do
       end
     end
 
+    context "set --active flag " do
+      ARGV.replace(["list", "--active"])
+
+      it "is a valid option" do
+        expect { capture_io { cli.start } }.to_not raise_error
+      end
+    end
+
     context "no arguments are given" do
       ARGV.replace(["list"])
 

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -281,6 +281,26 @@ describe Tmuxinator::Config do
         to eq ["both", "both", "dup/local-dup", "home", "local-dup", "xdg"]
     end
 
+    it "gets a sorted list of all active projects" do
+      allow(described_class).to receive(:environment?).and_return false
+      allow(described_class).
+        to receive(:active_sessions).
+        and_return ["both", "home"]
+
+      expect(described_class.configs(active: true)).
+        to eq ["both", "home"]
+    end
+
+    it "gets a sorted list excluding active projects" do
+      allow(described_class).to receive(:environment?).and_return false
+      allow(described_class).
+        to receive(:active_sessions).
+        and_return ["both", "home"]
+
+      expect(described_class.configs(active: false)).
+        to eq ["dup/local-dup", "local-dup", "xdg"]
+    end
+
     it "lists only projects in $TMUXINATOR_CONFIG when set" do
       allow(ENV).to receive(:[]).with("TMUXINATOR_CONFIG").
         and_return "#{fixtures_dir}/TMUXINATOR_CONFIG"


### PR DESCRIPTION
### Metadata

Fixes #933

### Problem / Motivation

See https://github.com/tmuxinator/tmuxinator/issues/933

Users want to be able to list projects and filter them by those that are already started or not.

### Solution

- [x] CHANGELOG entry is added for code changes

Introduce an `--active`/`-a` option to `tmuxinator list`

### Testing

I added tests to cover active: true and active: false cases.

Test it yourself:

```
# The dots and tmuxinator projects are active
$ bundle exec tmuxinator list --active
tmuxinator projects:
dots        tmuxinator

# The dots and tmuxinator projects are not shown when active, given `-a false`
$ bundle exec tmuxinator list -a false
tmuxinator projects:
173                            410                            651                            856
...
```
