### PR TITLE
chore: Bump tmuxinator to v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## 3.3.2
 ### Misc
 - Bump patch versions of Ruby 3.1, 3.2, 3.3 in the test matrix
 ### tmux

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.3.1"
+  VERSION = "3.3.2"
 end


### PR DESCRIPTION
## 3.3.2
### Misc
- Bump patch versions of Ruby 3.1, 3.2, 3.3 in the test matrix
### tmux
- Add tmux 3.5a to test matrix