### PR TITLE
feat: Add --no-pre-window option to start command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Features
 - Add support for tmuxinator start --append
+- Add support for tmuxinator start --no-pre-window
 ### Fixes
 - Properly pass additional arguments to the start command when no command is given
 

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -176,29 +176,22 @@ module Tmuxinator
       end
 
       def create_project(project_options = {})
-        # Strings provided to --attach are coerced into booleans by Thor.
-        # "f" and "false" will result in `:attach` being `false` and any other
-        # string or the empty flag will result in `:attach` being `true`.
-        # If the flag is not present, `:attach` will be `nil`.
-        attach = detach = false
-        attach = true if project_options[:attach] == true
-        detach = true if project_options[:attach] == false
+        Tmuxinator::Config.validate(project_create_options(project_options))
+      rescue StandardError => e
+        exit! e.message
+      end
 
-        options = {
+      def project_create_options(project_options)
+        {
           args: project_options[:args],
           custom_name: project_options[:custom_name],
-          force_attach: attach,
-          force_detach: detach,
+          force_attach: project_options[:attach] == true,
+          force_detach: project_options[:attach] == false,
           name: project_options[:name],
           project_config: project_options[:project_config],
-          append: project_options[:append]
+          append: project_options[:append],
+          no_pre_window: project_options[:no_pre_window],
         }
-
-        begin
-          Tmuxinator::Config.validate(options)
-        rescue StandardError => e
-          exit! e.message
-        end
       end
 
       def render_project(project)
@@ -244,6 +237,7 @@ module Tmuxinator
           name: name,
           project_config: options["project-config"],
           append: options["append"],
+          no_pre_window: options["no-pre-window"],
         }
       end
     end
@@ -262,6 +256,8 @@ module Tmuxinator
     method_option :append, type: :boolean,
                            desc: "Appends the project windows and panes in " \
                                  "the current session"
+    method_option "no-pre-window", type: :boolean, default: false,
+                                   desc: "Skip pre_window commands"
     def start(name = nil, *args)
       params = start_params(name, *args)
 
@@ -323,7 +319,8 @@ module Tmuxinator
     method_option :append, type: :boolean,
                            desc: "Appends the project windows and panes in " \
                                  "the current session"
-
+    method_option "no-pre-window", type: :boolean, default: false,
+                                   desc: "Skip pre_window commands"
     def debug(name = nil, *args)
       params = start_params(name, *args)
 

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -40,6 +40,7 @@ module Tmuxinator
     attr_reader :force_attach
     attr_reader :force_detach
     attr_reader :custom_name
+    attr_reader :no_pre_window
 
     def self.load(path, options = {})
       yaml = begin
@@ -83,15 +84,19 @@ module Tmuxinator
 
       @yaml = yaml
 
-      @custom_name = options[:custom_name]
-
-      @force_attach = options[:force_attach]
-      @force_detach = options[:force_detach]
-      @append = options[:append]
+      set_instance_variables_from_options(options)
 
       validate_options
 
       extend Tmuxinator::WemuxSupport if wemux?
+    end
+
+    def set_instance_variables_from_options(options)
+      @custom_name = options[:custom_name]
+      @force_attach = options[:force_attach]
+      @force_detach = options[:force_detach]
+      @append = options[:append]
+      @no_pre_window = options[:no_pre_window]
     end
 
     def validate_options
@@ -165,6 +170,8 @@ module Tmuxinator
     end
 
     def pre_window
+      return if no_pre_window
+
       params = if rbenv?
                  "rbenv shell #{yaml['rbenv']}"
                elsif rvm?

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -281,6 +281,16 @@ describe Tmuxinator::Project do
         end
       end
     end
+
+    context "no_pre_window option is true" do
+      before do
+        allow(project).to receive_messages(no_pre_window: true)
+      end
+
+      it "returns nil" do
+        expect(pre_window).to be_nil
+      end
+    end
   end
 
   describe "#socket" do


### PR DESCRIPTION
### Metadata

https://github.com/tmuxinator/tmuxinator/pull/908#issuecomment-2127709831

### Problem / Motivation

Sometimes, you don't want to have the `pre_window` command run when starting a project.

This may especially be true if you are using the `--append` option to add windows to an existing session.

### Solution

- [X] CHANGELOG entry is added for code changes

Add a new `--no-pre-window` option that applies to both `start` and `debug`.

### Testing

I've been testing with a basic project yaml like this:

```yaml
name: test
root: /tmp

pre_window: echo pre_window

windows:
  - window1:
      panes:
        - echo 'window 1, pane 1'
        - echo 'window 1, pane 2'
  - window2: echo window2
  - window3: echo window3
```

When you start the project with `--no-pre-window`, you shouldn't see the `echo pre_window`.

```sh
bundle exec tmuxinator start test --no-pre-window

# alternative ways to call it
bundle exec tmuxinator test --no-pre-window
bundle exec tmuxinator test --no-pre-window true

# default
bundle exec tmuxinator test --no-pre-window false
```

Without `pre_window` (first window of the first pane shown):

```sh
echo 'window 1, pane 2'

akofink@akmac: /tmp $ echo 'window 1, pane 2'
window 1, pane 2

akofink@akmac: /tmp $
```

With `pre_window`:

```sh
echo pre_window
echo 'window 1, pane 1'

akofink@akmac: /tmp $ echo pre_window
pre_window
echo 'window 1, pane 1'

akofink@akmac: /tmp $ echo 'window 1, pane 1'
window 1, pane 1
```