### PR TITLE
fix: Properly pass args to start when no command is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 ### Features
 - Add support for tmuxinator start --append
+### Fixes
+- Properly pass additional arguments to the start command when no command is given
 
 ## 3.3.3
 ### Features

--- a/lib/tmuxinator/cli.rb
+++ b/lib/tmuxinator/cli.rb
@@ -438,7 +438,7 @@ module Tmuxinator
         Tmuxinator::Cli.new.local
       elsif name && !Tmuxinator::Cli::RESERVED_COMMANDS.include?(name) &&
             Tmuxinator::Config.exist?(name: name)
-        Tmuxinator::Cli.new.start(name, *args.drop(1))
+        Tmuxinator::Cli.start([:start, *args])
       else
         Tmuxinator::Cli.start(args)
       end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -99,9 +99,7 @@ describe Tmuxinator::Cli do
           end
 
           it "should call #start" do
-            instance = instance_double(cli)
-            expect(cli).to receive(:new).and_return(instance)
-            expect(instance).to receive(:start).with(*args)
+            expect(cli).to receive(:start).with([:start, *args])
             subject
           end
 
@@ -109,9 +107,7 @@ describe Tmuxinator::Cli do
             let(:args) { ["sample", "--append"] }
 
             it "should call #start" do
-              instance = instance_double(cli)
-              expect(cli).to receive(:new).and_return(instance)
-              expect(instance).to receive(:start).with("sample", "--append")
+              expect(cli).to receive(:start).with([:start, *args])
               subject
             end
           end


### PR DESCRIPTION
### Metadata

Links to relevant docs, related PRs or issues, etc.

### Problem / Motivation

`mux start [project] [args]` should behave the same as `mux [project] [args]`.

Currently, the args are not passed through to the start command as Thor `options` - they come through as args instead.

I noticed this when recently implementing the `--append` and `--no-pre-window` options on the `start` command.

### Solution

- [X] CHANGELOG entry is added for code changes

Fix the call to Tmuxinator::Cli#start when a project name is passed in by simply appending `:start` to the args, as the first argument is the subcommand in Thor::Cli.

### Testing

Describe any interesting automated test changes

`test.yml` tmuxinator project config:

```test.yml
name: test
root: /tmp

windows:
  - window1:
      panes:
        - echo 'window 1, pane 1'
        - echo 'window 1, pane 2'
  - window2: echo window2
  - window3: echo window3
```

Try it with `--append` as an example. Trying it outside an existing tmux session should error:

```sh
$ (cd ~/dev/repos/tmuxinator; bundle exec tmuxinator test --append)
Cannot append to a session that does not exist
```