### PR TITLE
chore: Fix coveralls to run from GH actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,3 +73,18 @@ jobs:
       run: |
         bundle install
         bundle exec rake test
+    - name: Coveralls
+      uses: coverallsapp/github-action@v2
+      with:
+        flag-name: run-${{ join(matrix.*, '-') }}
+        parallel: true
+  finish:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true
+        carryforward: "run-3.3.5-1.5,run-3.3.5-2.6,run-3.3.5-3.5a"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-.coveralls.yml
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Add support for tmuxinator start --no-pre-window
 ### Fixes
 - Properly pass additional arguments to the start command when no command is given
+### Misc
+- Fix code coverage reporting via coveralls, now with GitHub Actions
 
 ## 3.3.3
 ### Features

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,21 @@
 # frozen_string_literal: true
 
-require "coveralls"
 require "pry"
 require "simplecov"
 require "xdg"
 
-formatters = [
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(formatters)
 SimpleCov.start do
+  if ENV["CI"]
+    formatter SimpleCov::Formatter::SimpleFormatter
+  else
+    formatter SimpleCov::Formatter::MultiFormatter.new(
+      [
+        SimpleCov::Formatter::HTMLFormatter,
+        SimpleCov::Formatter::SimpleFormatter,
+      ]
+    )
+  end
+
   add_filter "vendor/cache"
 end
 

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -46,7 +46,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "awesome_print", "~> 1.2"
   s.add_development_dependency "bundler", ">= 1.3"
-  s.add_development_dependency "coveralls", "~> 0.8"
   s.add_development_dependency "factory_bot", "~> 4.8"
   s.add_development_dependency "pry", "~> 0.10"
   s.add_development_dependency "rake", "~> 12.3.3"


### PR DESCRIPTION
### Metadata

Related discussion in https://github.com/tmuxinator/tmuxinator/issues/944

https://coveralls.io/github/tmuxinator/tmuxinator

[Example parallel CI setup from the coveralls GitHub Action docs](https://github.com/coverallsapp/github-action?tab=readme-ov-file#complete-parallel-job-example)

### Problem / Motivation

Coveralls reporting seems to have been broken since 2021, when the project was still using Travis CI

### Solution

- [x] CHANGELOG entry is added for code changes

Rely on the Github Action for coveralls, which doesn't even require the gem. It's able to parse SimpleCov format directly.

### Testing

No tests were changed

Check the CI pipeline if you want to see the coveralls action in each step and also at the end
