### PR TITLE
chore: Bump tmuxinator to v3.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## 3.3.4
 ### Features
 - Add support for tmuxinator start --append
 - Add support for tmuxinator start --no-pre-window

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.3.3"
+  VERSION = "3.3.4"
 end


### PR DESCRIPTION
## 3.3.4
### Features
- Add support for tmuxinator start --append
- Add support for tmuxinator start --no-pre-window
### Fixes
- Properly pass additional arguments to the start command when no command is given
### Misc
- Fix code coverage reporting via coveralls, now with GitHub Actions