### PR TITLE
chore: Test against Ruby 3.4 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '3.3.5'
-          - '3.2.5'
+          - '3.4.2'
+          - '3.3.7'
+          - '3.2.7'
           - '3.1.6'
         tmux_version:
           - '3.5a'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+## Misc
+- Add Ruby 3.4 to the test matrix
 
 ## 3.3.4
 ### Features

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -44,14 +44,14 @@ Gem::Specification.new do |s|
   s.add_dependency "thor", "~> 1.3.0"
   s.add_dependency "xdg", "~> 2.2", ">= 2.2.5"
 
-  s.add_development_dependency "awesome_print", "~> 1.2"
+  s.add_development_dependency "awesome_print", "~> 1.9"
   s.add_development_dependency "bundler", ">= 1.3"
-  s.add_development_dependency "factory_bot", "~> 4.8"
-  s.add_development_dependency "pry", "~> 0.10"
-  s.add_development_dependency "rake", "~> 12.3.3"
+  s.add_development_dependency "factory_bot", "~> 6.5"
+  s.add_development_dependency "pry", "~> 0.15"
+  s.add_development_dependency "rake", "~> 13.2"
   s.add_development_dependency "rspec", "~> 3.3"
   s.add_development_dependency "rubocop", "~> 0.61.1"
-  s.add_development_dependency "simplecov", "~> 0.16"
+  s.add_development_dependency "simplecov", "~> 0.22"
 
   # quiet "Gem.gunzip is deprecated" deprecation warning caused by rubocop
   s.add_development_dependency "unicode-display_width", "~> 1.3"


### PR DESCRIPTION
### Metadata

Fixes #944 

https://www.ruby-lang.org/en/downloads/branches/

### Problem / Motivation

Ruby 3.4 released on 2024-12-25

We're currently not testing against 3.4

### Solution

- [X] CHANGELOG entry is added for code changes

Add Ruby 3.4.2 to our CI pipelines

Update patch versions of other older Ruby versions in CI

Update some development gem constraints to support 3.4

### Testing

You can manually test against ruby 3.4:

```sh
rbenv install 3.4.2
rbenv shell 3.4.2

bundle exec tmuxinator ...

# Run tests locally
bundle exec rake test
```

The GitHub actions output will also contain tests against Ruby 3.4
