### PR TITLE
doc: Document `new [project] [session]` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ## Misc
 - Add Ruby 3.4 to the test matrix
+- Document new from session feature in the README
 
 ## 3.3.4
 ### Features

--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ windows:
   - logs: tail -f log/development.log
 ```
 
+It's also possible to create a new tmuxinator project from an existing tmux
+session. This can be done by running the following command:
+
+```bash
+tmuxinator new [project] [session]
+```
+
+This will record the windows, along with their specified layout, panes,
+tmux session options, and project root based on the tmux
+default-path of the specified tmux session in the new tmuxinator project.
+
 ## Windows
 
 The windows option allows the specification of any number of tmux windows. Each window is denoted by a YAML array entry, followed by a name* and command to be run.


### PR DESCRIPTION
### Metadata

Fixes #940

### Problem / Motivation

This command is currently undocumented:

```sh
tmuxinator new [project] [session]
```

### Solution

- [X] CHANGELOG entry is added for code changes

Add documentation in the readme about how this works and what it supports

### Testing

N/A for a pure doc change
