### PR TITLE
fix: Properly parse args with equals (=) in their value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Misc
 - Add Ruby 3.4 to the test matrix
 - Document new from session feature in the README
+## Fixes
+- Properly pass args with equals (=) in their values
 
 ## 3.3.4
 ### Features

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -62,7 +62,7 @@ module Tmuxinator
       args.reject! { |x| x.match(/.*=.*/) }
 
       settings.map! do |setting|
-        parts = setting.split("=")
+        parts = setting.split("=", 2)
         [parts[0], parts[1]]
       end
 

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -665,7 +665,7 @@ describe Tmuxinator::Project do
   end
 
   describe "::parse_settings" do
-    let(:args) { ["one", "two=three"] }
+    let(:args) { ["one", "two=three", "four=five=six"] }
 
     it "returns settings in a hash" do
       expect(described_class.parse_settings(args)["two"]).to eq("three")
@@ -674,6 +674,10 @@ describe Tmuxinator::Project do
     it "removes settings from args" do
       described_class.parse_settings(args)
       expect(args).to eq(["one"])
+    end
+
+    it "handles equals signs in values" do
+      expect(described_class.parse_settings(args)["four"]).to eq("five=six")
     end
   end
 


### PR DESCRIPTION
### Metadata

Fixes #879

### Problem / Motivation

Arguments passed to `tmuxinator start [project] [args]` with an equals sign (=) drops everything after the equals sign.

Example:

```sh
tmuxinator start 879 value='set value = this'
```

### Solution

- [X] CHANGELOG entry is added for code changes

Limit the `.split('=', 2)` call as shown to 2 halves (1 split on the first `=`)

### Testing

I added a test that demonstrates the issue without the code changes.

```sh
Failures:

  1) Tmuxinator::Project::parse_settings handles equals signs in values
     Failure/Error: expect(described_class.parse_settings(args)["four"]).to eq("five=six")

       expected: "five=six"
            got: "five"

       (compared using ==)
```
