### PR TITLE
fix: Fix `fish-shell` completions (857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Document new from session feature in the README
 ## Fixes
 - Properly pass args with equals (=) in their values
+- Fix `fish-shell` completion
 
 ### Features
 - Add support for tmuxinator stop-all

--- a/completion/tmuxinator.fish
+++ b/completion/tmuxinator.fish
@@ -1,22 +1,17 @@
 function __fish_tmuxinator_using_command
-  set cmd (commandline -opc)
-  if [ (count $cmd) -gt 1 ]
-    if [ $argv[1] = $cmd[2] ]
-      return 0
+    set cmd (commandline -opc)
+    if [ (count $cmd) -gt 1 ]
+        if [ $argv[1] = $cmd[2] ]
+            return 0
+        end
     end
-  end
-  return 1
+    return 1
 end
 
-set __fish_tmuxinator_program_cmd (commandline -o)[1]
-
-function __fish_tmuxinator_program
-  eval "$__fish_tmuxinator_program_cmd $argv"
-end
-
-complete -f -c $__fish_tmuxinator_program_cmd                                                -a '(__fish_tmuxinator_program completions start)'
-complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_use_subcommand'                  -x -a "(__fish_tmuxinator_program commands)"
-complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command start'     -a "(__fish_tmuxinator_program completions start)"
-complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command open'      -a "(__fish_tmuxinator_program completions open)"
-complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command copy'      -a "(__fish_tmuxinator_program completions copy)"
-complete -f -c $__fish_tmuxinator_program_cmd -n '__fish_tmuxinator_using_command delete'    -a "(__fish_tmuxinator_program completions delete)"
+complete --no-files --command tmuxinator --condition __fish_use_subcommand --exclusive --argument "(tmuxinator commands)"
+complete --no-files --command tmuxinator --condition '__fish_tmuxinator_using_command start' --argument "(tmuxinator completions start)"
+complete --no-files --command tmuxinator --condition '__fish_tmuxinator_using_command open' --argument "(tmuxinator completions open)"
+complete --no-files --command tmuxinator --condition '__fish_tmuxinator_using_command edit' --argument "(tmuxinator completions open)"
+complete --no-files --command tmuxinator --condition '__fish_tmuxinator_using_command copy' --argument "(tmuxinator completions copy)"
+complete --no-files --command tmuxinator --condition '__fish_tmuxinator_using_command delete' --argument "(tmuxinator completions delete)"
+complete --no-files --command tmuxinator --condition '__fish_tmuxinator_using_command debug' --argument "(tmuxinator completions start)"


### PR DESCRIPTION
Refactors `fish-shell` completion so that it works as expected.

### Metadata

Fixes https://github.com/tmuxinator/tmuxinator/issues/857

### Problem / Motivation

Fixing `fish-shell` completions. In my case, I was noticing that completions for `tmuxinator` did not work at all, either when typing `tmuxinator<TAB>` or when using my `mux` alias set in my `~/.config/fish/config.fish` file, via `alias mux="tmuxinator"`.

### Solution

- [x] CHANGELOG entry is added for code changes

Removes some problematic logic around getting a reference to the un-aliased/aliased `tmuxinator` command a-la `set __fish_tmuxinator_program_cmd (commandline -o)[1]`. 

If `fish` users are using an alias like `mux`, `fish` should already be able to map this to the underlying `tmuxinator` command: https://fishshell.com/docs/current/cmds/alias.html#example, so this logic is unnecessary and was the cause that fish shell completions were not working. By replacing references to this with `tmuxinator`, the shell completion now works

#### QOL Updates
Unnecessary, but I've made a couple additional updates for QOL purposes:
- Using the long option names for `complete` for better readability.
- Adds completions for the `edit` and `debug` commands. They use the same completion logic as `tmuxinator completions start`, so it's sort of a hack, but since we should be able to edit/debug the same projects, I just used the same underlying command to get the available projects.

### Testing

| Before | After |
| -------------- | --------------- |
| ![mux_commands_before](https://github.com/user-attachments/assets/d28afa3c-3fac-4812-b9b1-7f288ccc8652) | ![mux_commands](https://github.com/user-attachments/assets/560fe285-cef5-4ea4-8404-9385424b1c4f)|
