### PR TITLE
chore: Bump tmuxinator to 3.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## 3.3.5
 ## Misc
 - Add Ruby 3.4 to the test matrix
 - Document new from session feature in the README
@@ -8,7 +10,6 @@
 ## Fixes
 - Properly pass args with equals (=) in their values
 - Fix `fish-shell` completion
-
 ### Features
 - Add support for tmuxinator stop-all
 

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.3.4"
+  VERSION = "3.3.5"
 end


### PR DESCRIPTION
## 3.3.5
## Misc
- Add Ruby 3.4 to the test matrix
- Document new from session feature in the README
- Update required Ruby version to >=2.7 
- Update runtime dependencies to up-to-date versions
- Update development dependencies to up-to-date versions
## Fixes
- Properly pass args with equals (=) in their values
- Fix `fish-shell` completion
### Features
- Add support for tmuxinator stop-all