### PR TITLE
chore: Update Ruby versions in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '3.4.2'
-          - '3.3.7'
-          - '3.2.7'
-          - '3.1.6'
+          - '3.4.5'
+          - '3.3.9'
+          - '3.2.9'
         tmux_version:
           - '3.5a'
           - '3.5'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+## Misc
+- Update CI ruby versions to latest, remove Ruby 3.1
 
 ## 3.3.5
 ## Misc


### PR DESCRIPTION
### Metadata

https://www.ruby-lang.org/en/downloads/branches/

### Problem / Motivation

We're testing against Ruby 3.1, which went EOL on 2025-03-26

We're similarly not testing against the latest patch versions of supported Ruby versions.

### Solution

- [x] CHANGELOG entry is added for code changes

Remove Ruby 3.1 from ci.yaml.

Update the ci.yaml with the latest patch versions.

### Testing

In GitHub actions output.
