### PR TITLE
ci: streamline PR verification and tmux compatibility tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,93 +1,82 @@
+---
 # continuous integration workflow based on old travis-ci configuration
 
-name: Integration Tests
-on:
-  - push
-  - pull_request
+name: CI
+
+"on":
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
-  test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0.1'
+          bundler-cache: true
+
+      - name: Lint
+        run: bundle exec rake lint
+
+  unit:
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0.1'
+          bundler-cache: true
+
+      - name: Unit tests
+        run: bundle exec rake unit
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: unit
+
+  interface:
+    needs: unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0.1'
+          bundler-cache: true
+
+      - name: Interface snapshots
+        run: bundle exec rake interface
+
+  ruby-compatibility:
+    needs: interface
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby_version:
-          - '4.0.1'
+        ruby-version:
           - '3.4.8'
           - '3.3.10'
           - '3.2.10'
-        tmux_version:
-          - '3.6a'
-          - '3.6'
-          - '3.5a'
-          - '3.5'
-          - '3.4'
-          - '3.3a'
-          - '3.3'
-          - '3.2a'
-          - '3.2'
-          - '3.1c'
-          - '3.1b'
-          - '3.1a'
-          - '3.1'
-          - '3.0a'
-          - '3.0'
-          - '2.9a'
-          - '2.9'
-          - '2.8'
-          - '2.7'
-          - '2.6'
-          - '2.5'
-          - '2.4'
-          - '2.3'
-          - '2.2'
-          - '2.1'
-          - '2.0'
-          - '1.9'
-          - '1.8'
-          - '1.7'
-          - '1.6'
-          - '1.5'
-
     steps:
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
-        bundler-cache: true
+      - uses: actions/checkout@v6
 
-    - name: "Install tmux ${{ matrix.tmux_version }}"
-      run: |
-        # build dependencies
-        sudo apt-get update -qq
-        # note: pkg-config must be installed before dep libs or the build fails
-        sudo apt-get install -y -qq pkg-config build-essential autoconf automake bison git
-        sudo apt-get install -y libevent-dev libncurses-dev
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
 
-        # build and install tmux
-        git clone https://github.com/tmux/tmux.git tmux
-        cd tmux
-        git checkout ${{ matrix.tmux_version }}
-        bash autogen.sh
-        bash ./configure && make && sudo make install
-        cd ..
-        tmux -V
-
-    - uses: actions/checkout@v6
-    - name: "Test ruby ${{ matrix.ruby_version }} tmux ${{ matrix.tmux_version }}"
-      run: |
-        bundle install
-        bundle exec rake test
-    - name: Coveralls
-      uses: coverallsapp/github-action@v2
-      with:
-        flag-name: run-${{ join(matrix.*, '-') }}
-        parallel: true
-  finish:
-    needs: test
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel-finished: true
-        carryforward: "run-3.3.5-1.5,run-3.3.5-2.6,run-3.3.5-3.5a"
+      - name: Compatibility tests
+        run: |
+          bundle exec rake unit
+          bundle exec rake interface

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,16 @@ require "rubocop/rake_task"
 require "rspec/core/rake_task"
 
 RuboCop::RakeTask.new
-RSpec::Core::RakeTask.new
+RSpec::Core::RakeTask.new(:unit) do |task|
+  task.pattern = "spec/lib/**/*_spec.rb"
+end
 
-task test: ["spec", "rubocop"]
+RSpec::Core::RakeTask.new(:interface) do |task|
+  task.pattern = "spec/interface/**/*_spec.rb"
+end
+
+task lint: :rubocop
+
+task test: ["lint", "unit", "interface"]
+
+task default: :test

--- a/spec/fixtures/interface/basic.yml
+++ b/spec/fixtures/interface/basic.yml
@@ -1,0 +1,14 @@
+name: basic
+root: /workspace/basic
+tmux_options: -L interface
+pre_window: bundle exec ruby -v
+windows:
+  - editor:
+      root: app
+      panes:
+        - bundle exec vim
+        - bundle exec rake test
+  - shell:
+      root: .
+      panes:
+        - bin/setup

--- a/spec/fixtures/interface/pane_titles.yml
+++ b/spec/fixtures/interface/pane_titles.yml
@@ -1,0 +1,11 @@
+name: pane-titles
+root: /workspace/pane-titles
+tmux_options: -L interface
+enable_pane_titles: true
+pane_title_position: bottom
+pane_title_format: "[ #T ]"
+windows:
+  - editor:
+      panes:
+        - editor: bundle exec vim
+        - logs: tail -f log/test.log

--- a/spec/interface/debug_snapshot_spec.rb
+++ b/spec/interface/debug_snapshot_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "tmuxinator debug snapshots" do
+  let(:cli) { Tmuxinator::Cli }
+  let(:snapshot_root) { File.expand_path("../snapshots/debug", __dir__) }
+
+  around do |example|
+    original_argv = ARGV.dup
+    example.run
+    ARGV.replace(original_argv)
+  end
+
+  before do
+    allow_any_instance_of(Tmuxinator::Project).
+      to receive(:extract_tmux_config).
+      and_return({ "base-index" => "0", "pane-base-index" => "0" })
+    allow_any_instance_of(Tmuxinator::Project).
+      to receive(:tmux_has_session?).
+      and_return(false)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("SHELL").and_return("/bin/bash")
+  end
+
+  {
+    "1.6" => 1.6,
+    "1.8" => 1.8,
+    "2.6" => 2.6,
+  }.each do |version_label, version|
+    {
+      "basic" => "spec/fixtures/interface/basic.yml",
+      "pane_titles" => "spec/fixtures/interface/pane_titles.yml",
+    }.each do |fixture_name, fixture_path|
+      it "matches #{fixture_name} output for tmux #{version_label}" do
+        allow(Tmuxinator::Config).to receive(:version).and_return(version)
+
+        ARGV.replace(["debug", "--project-config=#{fixture_path}"])
+        output, _err = capture_io { cli.start }
+
+        snapshot_path = File.join(
+          snapshot_root,
+          version_label,
+          "#{fixture_name}.sh"
+        )
+
+        expect(output).to eq("#{File.read(snapshot_path)}\n")
+      end
+    end
+  end
+end

--- a/spec/lib/tmuxinator/cli_spec.rb
+++ b/spec/lib/tmuxinator/cli_spec.rb
@@ -717,27 +717,34 @@ describe Tmuxinator::Cli do
 
     # this command variant only works for tmux version 1.6 and up.
     context "from a session" do
-      context "with tmux >= 1.6", if: Tmuxinator::Config.version >= 1.6 do
+      context "with tmux >= 1.6" do
+        let(:success_status) { instance_double(Process::Status, success?: true) }
+        let(:failure_status) { instance_double(Process::Status, success?: false) }
+
         before do
-          # Necessary to make `Doctor.installed?` work in specs
-          allow(Tmuxinator::Doctor).to receive(:installed?).and_return(true)
+          allow(Tmuxinator::Config).to receive(:version).and_return(1.6)
         end
 
         context "session exists" do
-          before(:all) do
-            # Can't add variables through `let` in `before :all`.
-            @session = "for-testing-tmuxinator"
-            # Pass the -d option, so that the session is not attached.
-            Kernel.system "tmux new-session -d -s #{@session}"
-          end
-
           before do
-            ARGV.replace ["new", name, @session]
-          end
-
-          after(:all) do
-            puts @session
-            Kernel.system "tmux kill-session -t #{@session}"
+            ARGV.replace ["new", name, "existing-session"]
+            allow(Open3).to receive(:capture3).and_return(
+              [
+                "editor tiled 1 /workspace/app\n",
+                "",
+                success_status,
+              ],
+              [
+                "editor /workspace/app\n",
+                "",
+                success_status,
+              ],
+              [
+                "default-path \"/workspace/app\"\n",
+                "",
+                success_status,
+              ]
+            )
           end
 
           it "creates a project file" do
@@ -751,6 +758,11 @@ describe Tmuxinator::Cli do
         context "session doesn't exist" do
           before do
             ARGV.replace ["new", name, "sessiondoesnotexist"]
+            allow(Open3).to receive(:capture3).and_return(
+              ["", "", failure_status],
+              ["", "", failure_status],
+              ["", "", failure_status]
+            )
           end
 
           it "fails" do

--- a/spec/snapshots/debug/1.6/basic.sh
+++ b/spec/snapshots/debug/1.6/basic.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+
+  # Clear rbenv variables before starting tmux
+  unset RBENV_VERSION
+  unset RBENV_DIR
+
+  tmux -L interface start-server;
+
+cd /workspace/basic
+
+# Run on_project_start command.
+
+
+
+  # Run pre command.
+  
+
+  # Run on_project_first_start command.
+  
+
+  tmux -L interface new-session -d -s basic -n editor
+
+  # Set the default path for versions prior to 1.7
+  tmux -L interface set-option -t basic default-path /workspace/basic 1>/dev/null
+
+
+  # Create windows.
+  tmux -L interface new-window default-path /workspace/basic/app -k -t basic:0 -n editor
+  tmux -L interface new-window default-path /workspace/basic -k -t basic:1 -n shell
+
+
+  # Window "editor"
+
+
+  tmux -L interface send-keys -t basic:0.0 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:0.0 bundle\ exec\ vim C-m
+
+  tmux -L interface splitw default-path /workspace/basic/app -t basic:0
+  tmux -L interface select-layout -t basic:0 tiled
+  tmux -L interface send-keys -t basic:0.1 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:0.1 bundle\ exec\ rake\ test C-m
+
+  tmux -L interface select-layout -t basic:0 tiled
+
+  tmux -L interface select-layout -t basic:0 
+  tmux -L interface select-pane -t basic:0.0
+
+
+  # Window "shell"
+
+
+  tmux -L interface send-keys -t basic:1.0 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:1.0 bin/setup C-m
+
+  tmux -L interface select-layout -t basic:1 tiled
+
+  tmux -L interface select-layout -t basic:1 
+  tmux -L interface select-pane -t basic:1.0
+
+
+  tmux -L interface select-window -t basic:0
+  tmux -L interface select-pane -t basic:0.0
+
+  if [ -z "$TMUX" ]; then
+    tmux -L interface -u attach-session -t basic
+  else
+    tmux -L interface -u switch-client -t basic
+  fi
+
+
+
+# Run on_project_exit command.

--- a/spec/snapshots/debug/1.6/pane_titles.sh
+++ b/spec/snapshots/debug/1.6/pane_titles.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+
+  # Clear rbenv variables before starting tmux
+  unset RBENV_VERSION
+  unset RBENV_DIR
+
+  tmux -L interface start-server;
+
+cd /workspace/pane-titles
+
+# Run on_project_start command.
+
+
+
+  # Run pre command.
+  
+
+  # Run on_project_first_start command.
+  
+
+  tmux -L interface new-session -d -s pane-titles -n editor
+
+  # Set the default path for versions prior to 1.7
+  tmux -L interface set-option -t pane-titles default-path /workspace/pane-titles 1>/dev/null
+
+  printf "\033[1;33mWARNING: You have enabled pane titles in your configuration, but the feature is not supported by your version of tmux.
+Please consider upgrading to a version that supports it (tmux >=2.6).
+\033[0m"
+
+  # Create windows.
+  tmux -L interface new-window default-path /workspace/pane-titles -k -t pane-titles:0 -n editor
+
+
+  # Window "editor"
+
+
+  tmux -L interface send-keys -t pane-titles:0.0 bundle\ exec\ vim C-m
+
+  tmux -L interface splitw default-path /workspace/pane-titles -t pane-titles:0
+  tmux -L interface select-layout -t pane-titles:0 tiled
+  tmux -L interface send-keys -t pane-titles:0.1 tail\ -f\ log/test.log C-m
+
+  tmux -L interface select-layout -t pane-titles:0 tiled
+
+  tmux -L interface select-layout -t pane-titles:0 
+  tmux -L interface select-pane -t pane-titles:0.0
+
+
+  tmux -L interface select-window -t pane-titles:0
+  tmux -L interface select-pane -t pane-titles:0.0
+
+  if [ -z "$TMUX" ]; then
+    tmux -L interface -u attach-session -t pane-titles
+  else
+    tmux -L interface -u switch-client -t pane-titles
+  fi
+
+
+
+# Run on_project_exit command.

--- a/spec/snapshots/debug/1.8/basic.sh
+++ b/spec/snapshots/debug/1.8/basic.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+
+  # Clear rbenv variables before starting tmux
+  unset RBENV_VERSION
+  unset RBENV_DIR
+
+  tmux -L interface start-server;
+
+cd /workspace/basic
+
+# Run on_project_start command.
+
+
+
+  # Run pre command.
+  
+
+  # Run on_project_first_start command.
+  
+
+  tmux -L interface new-session -d -s basic -n editor
+
+
+
+  # Create windows.
+  tmux -L interface new-window -c /workspace/basic/app -k -t basic:0 -n editor
+  tmux -L interface new-window -c /workspace/basic -k -t basic:1 -n shell
+
+
+  # Window "editor"
+
+
+  tmux -L interface send-keys -t basic:0.0 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:0.0 bundle\ exec\ vim C-m
+
+  tmux -L interface splitw -c /workspace/basic/app -t basic:0
+  tmux -L interface select-layout -t basic:0 tiled
+  tmux -L interface send-keys -t basic:0.1 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:0.1 bundle\ exec\ rake\ test C-m
+
+  tmux -L interface select-layout -t basic:0 tiled
+
+  tmux -L interface select-layout -t basic:0 
+  tmux -L interface select-pane -t basic:0.0
+
+
+  # Window "shell"
+
+
+  tmux -L interface send-keys -t basic:1.0 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:1.0 bin/setup C-m
+
+  tmux -L interface select-layout -t basic:1 tiled
+
+  tmux -L interface select-layout -t basic:1 
+  tmux -L interface select-pane -t basic:1.0
+
+
+  tmux -L interface select-window -t basic:0
+  tmux -L interface select-pane -t basic:0.0
+
+  if [ -z "$TMUX" ]; then
+    tmux -L interface -u attach-session -t basic
+  else
+    tmux -L interface -u switch-client -t basic
+  fi
+
+
+
+# Run on_project_exit command.

--- a/spec/snapshots/debug/1.8/pane_titles.sh
+++ b/spec/snapshots/debug/1.8/pane_titles.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+
+  # Clear rbenv variables before starting tmux
+  unset RBENV_VERSION
+  unset RBENV_DIR
+
+  tmux -L interface start-server;
+
+cd /workspace/pane-titles
+
+# Run on_project_start command.
+
+
+
+  # Run pre command.
+  
+
+  # Run on_project_first_start command.
+  
+
+  tmux -L interface new-session -d -s pane-titles -n editor
+
+
+  printf "\033[1;33mWARNING: You have enabled pane titles in your configuration, but the feature is not supported by your version of tmux.
+Please consider upgrading to a version that supports it (tmux >=2.6).
+\033[0m"
+
+  # Create windows.
+  tmux -L interface new-window -c /workspace/pane-titles -k -t pane-titles:0 -n editor
+
+
+  # Window "editor"
+
+
+  tmux -L interface send-keys -t pane-titles:0.0 bundle\ exec\ vim C-m
+
+  tmux -L interface splitw -c /workspace/pane-titles -t pane-titles:0
+  tmux -L interface select-layout -t pane-titles:0 tiled
+  tmux -L interface send-keys -t pane-titles:0.1 tail\ -f\ log/test.log C-m
+
+  tmux -L interface select-layout -t pane-titles:0 tiled
+
+  tmux -L interface select-layout -t pane-titles:0 
+  tmux -L interface select-pane -t pane-titles:0.0
+
+
+  tmux -L interface select-window -t pane-titles:0
+  tmux -L interface select-pane -t pane-titles:0.0
+
+  if [ -z "$TMUX" ]; then
+    tmux -L interface -u attach-session -t pane-titles
+  else
+    tmux -L interface -u switch-client -t pane-titles
+  fi
+
+
+
+# Run on_project_exit command.

--- a/spec/snapshots/debug/2.6/basic.sh
+++ b/spec/snapshots/debug/2.6/basic.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+
+  # Clear rbenv variables before starting tmux
+  unset RBENV_VERSION
+  unset RBENV_DIR
+
+  tmux -L interface start-server;
+
+cd /workspace/basic
+
+# Run on_project_start command.
+
+
+
+  # Run pre command.
+  
+
+  # Run on_project_first_start command.
+  
+
+  tmux -L interface new-session -d -s basic -n editor
+
+
+
+  # Create windows.
+  tmux -L interface new-window -c /workspace/basic/app -k -t basic:0 -n editor
+  tmux -L interface new-window -c /workspace/basic -k -t basic:1 -n shell
+
+
+  # Window "editor"
+
+
+  
+  tmux -L interface send-keys -t basic:0.0 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:0.0 bundle\ exec\ vim C-m
+
+  tmux -L interface splitw -c /workspace/basic/app -t basic:0
+  tmux -L interface select-layout -t basic:0 tiled
+  
+  tmux -L interface send-keys -t basic:0.1 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:0.1 bundle\ exec\ rake\ test C-m
+
+  tmux -L interface select-layout -t basic:0 tiled
+
+  tmux -L interface select-layout -t basic:0 
+  tmux -L interface select-pane -t basic:0.0
+
+
+  # Window "shell"
+
+
+  
+  tmux -L interface send-keys -t basic:1.0 bundle\ exec\ ruby\ -v C-m
+  tmux -L interface send-keys -t basic:1.0 bin/setup C-m
+
+  tmux -L interface select-layout -t basic:1 tiled
+
+  tmux -L interface select-layout -t basic:1 
+  tmux -L interface select-pane -t basic:1.0
+
+
+  tmux -L interface select-window -t basic:0
+  tmux -L interface select-pane -t basic:0.0
+
+  if [ -z "$TMUX" ]; then
+    tmux -L interface -u attach-session -t basic
+  else
+    tmux -L interface -u switch-client -t basic
+  fi
+
+
+
+# Run on_project_exit command.

--- a/spec/snapshots/debug/2.6/pane_titles.sh
+++ b/spec/snapshots/debug/2.6/pane_titles.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+
+  # Clear rbenv variables before starting tmux
+  unset RBENV_VERSION
+  unset RBENV_DIR
+
+  tmux -L interface start-server;
+
+cd /workspace/pane-titles
+
+# Run on_project_start command.
+
+
+
+  # Run pre command.
+  
+
+  # Run on_project_first_start command.
+  
+
+  tmux -L interface new-session -d -s pane-titles -n editor
+
+
+
+  # Create windows.
+  tmux -L interface new-window -c /workspace/pane-titles -k -t pane-titles:0 -n editor
+
+
+  # Window "editor"
+
+  tmux -L interface set-window-option -t pane-titles:0 pane-border-status bottom
+  tmux -L interface set-window-option -t pane-titles:0 pane-border-format "[ #T ]"
+
+  tmux -L interface select-pane -t pane-titles:0.0 -T editor
+  tmux -L interface send-keys -t pane-titles:0.0 bundle\ exec\ vim C-m
+
+  tmux -L interface splitw -c /workspace/pane-titles -t pane-titles:0
+  tmux -L interface select-layout -t pane-titles:0 tiled
+  tmux -L interface select-pane -t pane-titles:0.1 -T logs
+  tmux -L interface send-keys -t pane-titles:0.1 tail\ -f\ log/test.log C-m
+
+  tmux -L interface select-layout -t pane-titles:0 tiled
+
+  tmux -L interface select-layout -t pane-titles:0 
+  tmux -L interface select-pane -t pane-titles:0.0
+
+
+  tmux -L interface select-window -t pane-titles:0
+  tmux -L interface select-pane -t pane-titles:0.0
+
+  if [ -z "$TMUX" ]; then
+    tmux -L interface -u attach-session -t pane-titles
+  else
+    tmux -L interface -u switch-client -t pane-titles
+  fi
+
+
+
+# Run on_project_exit command.


### PR DESCRIPTION
### Metadata

- Scope: GitHub Actions CI, Rake tasks, CLI specs, interface snapshots
- Verification: `bundle exec rake lint`, `bundle exec rake unit`, `bundle exec rake interface`
- A bit of a rework of https://github.com/tmuxinator/tmuxinator/pull/980

### Problem

The pull request workflow was paying for a large Ruby x tmux matrix even though the default spec suite only exercised a small tmux-facing surface. That increased required checks, slowed feedback, and tied routine test execution to a live tmux dependency that most specs did not need.

### Solution

Replace the PR matrix with a fail-fast `lint -> unit -> interface` pipeline, make plain `rake` run that same verification flow, and remove the default suite's live tmux dependency from the CLI session import spec by stubbing tmux interaction. Add a snapshot-based interface suite around `tmuxinator debug` with canonical fixtures and representative tmux-version outputs so compatibility coverage focuses on generated commands instead of rebuilding tmux for every pull request.