### PR TITLE
fix: normalize tmux session names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Reintroduce `open` as an explicit create-or-open editor command
 - Reintroduce `edit` as an explicit existing-config editor command
+- Normalize project session names containing `.` or `:` to match tmux-created session names
 
 ## 3.3.8
 ### Features

--- a/lib/tmuxinator/project.rb
+++ b/lib/tmuxinator/project.rb
@@ -155,7 +155,7 @@ module Tmuxinator
           custom_name || yaml["project_name"] || yaml["name"]
         end
 
-      blank?(name) ? nil : name.to_s.shellescape
+      blank?(name) ? nil : name.to_s.tr(".:", "__").shellescape
     end
 
     def append?

--- a/spec/lib/tmuxinator/project_spec.rb
+++ b/spec/lib/tmuxinator/project_spec.rb
@@ -232,6 +232,22 @@ describe Tmuxinator::Project do
       end
     end
 
+    context "with dots" do
+      it "uses the session name tmux creates" do
+        project.yaml["project_name"] = "home.arpa"
+
+        expect(project.name).to eq "home_arpa"
+      end
+    end
+
+    context "with colons" do
+      it "uses the session name tmux creates" do
+        project.yaml["project_name"] = "home:arpa"
+
+        expect(project.name).to eq "home_arpa"
+      end
+    end
+
     context "as emoji" do
       it "will gracefully handle a name given as an emoji" do
         rendered = project_with_emoji_as_name


### PR DESCRIPTION
### Metadata

Relates to #93

### Problem

Tmux rewrites dots and colons in session names to underscores, so projects using those characters can create one session name and then target another when rendering tmux commands.

### Solution

Normalize dots and colons before shellescaping project session names, add regression coverage for both characters, and document the fix in the unreleased changelog.

- [x] CHANGELOG entry is added for code changes

### Testing

Added regression coverage for project names containing `.` and `:` to assert they normalize to the session name tmux creates.

Test project YAML:

```yaml
project_name: home.arpa
windows:
  - editor:
      panes:
        - echo ok
```

Reproducing steps:

```sh
tmuxinator debug home.arpa
```

Expected output includes tmux targets using `home_arpa`, for example:

```sh
tmux new-session -d -s home_arpa -n editor
tmux send-keys -t home_arpa:0 echo\ ok C-m
```