### PR TITLE
test: cover normalized tmux session targets

### DIFF
--- a/spec/fixtures/interface/session_name.yml
+++ b/spec/fixtures/interface/session_name.yml
@@ -1,0 +1,5 @@
+name: home.arpa:lab
+windows:
+  - main:
+      panes:
+        - echo ok

--- a/spec/interface/debug_snapshot_spec.rb
+++ b/spec/interface/debug_snapshot_spec.rb
@@ -48,4 +48,18 @@ describe "tmuxinator debug snapshots" do
       end
     end
   end
+
+  it "normalizes tmux session targets for project names with separators" do
+    allow(Tmuxinator::Config).to receive(:version).and_return(2.6)
+
+    ARGV.replace([
+                   "debug",
+                   "--project-config=spec/fixtures/interface/session_name.yml"
+                 ])
+    output, _err = capture_io { cli.start }
+
+    snapshot_path = File.join(snapshot_root, "2.6", "session_name.sh")
+
+    expect(output).to eq("#{File.read(snapshot_path)}\n")
+  end
 end

--- a/spec/snapshots/debug/2.6/session_name.sh
+++ b/spec/snapshots/debug/2.6/session_name.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+
+  # Clear rbenv variables before starting tmux
+  unset RBENV_VERSION
+  unset RBENV_DIR
+
+  tmux start-server;
+
+cd .
+
+# Run on_project_start command.
+
+
+
+  # Run pre command.
+  
+
+  # Run on_project_first_start command.
+  
+
+  tmux new-session -d -s home_arpa_lab -n main
+
+
+
+  # Create windows.
+  tmux new-window  -k -t home_arpa_lab:0 -n main
+
+
+  # Window "main"
+
+
+  
+  tmux send-keys -t home_arpa_lab:0.0 echo\ ok C-m
+
+  tmux select-layout -t home_arpa_lab:0 tiled
+
+  tmux select-layout -t home_arpa_lab:0 
+  tmux select-pane -t home_arpa_lab:0.0
+
+
+  tmux select-window -t home_arpa_lab:0
+  tmux select-pane -t home_arpa_lab:0.0
+
+  if [ -z "$TMUX" ]; then
+    tmux -u attach-session -t home_arpa_lab
+  else
+    tmux -u switch-client -t home_arpa_lab
+  fi
+
+
+
+# Run on_project_exit command.


### PR DESCRIPTION
### Problem

The session-name normalization fix from PR #983 is covered by unit specs, but the interface snapshot suite does not show reviewers the rendered tmux commands for project names containing separators.

### Solution

Add a minimal debug snapshot fixture for a project named `home.arpa:lab` so rendered session targets are checked as `home_arpa_lab`.