### PR TITLE
chore: Bump tmuxinator to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## Unreleased
-### Features
 
+
+## 3.4.0
+### Features
 - Add ability to focus panes via `focused_pane`
 ### Fixes
-
 - Reintroduce `open` as an explicit create-or-open editor command
 - Reintroduce `edit` as an explicit existing-config editor command
 - Normalize project session names containing `.` or `:` to match tmux-created session names
 ### Misc
-
 - Include tmux 3.6b in supported versions list
 
 ## 3.3.8

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.3.8"
+  VERSION = "3.4.0"
 end


### PR DESCRIPTION
## 3.4.0
### Features
- Add ability to focus panes via `focused_pane`
### Fixes
- Reintroduce `open` as an explicit create-or-open editor command
- Reintroduce `edit` as an explicit existing-config editor command
- Normalize project session names containing `.` or `:` to match tmux-created session names
### Misc
- Include tmux 3.6b in supported versions list