### PR TITLE
chore: Update ruby versions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,9 +65,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.4.8'
-          - '3.3.10'
-          - '3.2.10'
+          - '4.0.5'
+          - '3.4.9'
+          - '3.3.11'
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-
+### Misc
+- Update Ruby versions tested in CI interface tests
 
 ## 3.4.0
 ### Features


### PR DESCRIPTION
### Metadata

https://www.ruby-lang.org/en/downloads/branches/

### Problem / Motivation

Ruby 3.2 went EOL on April 1.

Ruby 4.0 was released Dec 25, 2025.

Stale Ruby patch versions included.

### Solution

- [X] CHANGELOG entry is added for code changes

Remove Ruby 3.2, bump 3.3 and 3.4, and add Ruby 4.0.

### Testing

N/A - it's all tests / CI