### PR TITLE
test: add interface snapshot update mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 ### Misc
+- Add `UPDATE_SNAPSHOTS` support for regenerating interface snapshots
 - Update Ruby versions tested in CI interface tests
 
 ## 3.4.0

--- a/README.md
+++ b/README.md
@@ -483,6 +483,21 @@ When this occurs, try putting your commands in a separate script and calling tha
 
 To contribute, please read the [contributing guide](https://github.com/tmuxinator/tmuxinator/blob/master/CONTRIBUTING.md).
 
+### Interface snapshots
+
+Run the interface snapshot tests with:
+
+```bash
+bundle exec rake interface
+```
+
+When an intentional change affects the generated shell script output, regenerate
+the snapshots with:
+
+```bash
+UPDATE_SNAPSHOTS=1 bundle exec rake interface
+```
+
 ## Copyright
 
 Copyright (c) 2010-2025 Allen Bargi, Christopher Chow. See LICENSE for further details.

--- a/spec/interface/debug_snapshot_spec.rb
+++ b/spec/interface/debug_snapshot_spec.rb
@@ -6,6 +6,14 @@ describe "tmuxinator debug snapshots" do
   let(:cli) { Tmuxinator::Cli }
   let(:snapshot_root) { File.expand_path("../snapshots/debug", __dir__) }
 
+  def expect_snapshot(output, snapshot_path)
+    if ENV["UPDATE_SNAPSHOTS"]
+      File.write(snapshot_path, output.delete_suffix("\n"))
+    else
+      expect(output).to eq("#{File.read(snapshot_path)}\n")
+    end
+  end
+
   around do |example|
     original_argv = ARGV.dup
     example.run
@@ -44,7 +52,7 @@ describe "tmuxinator debug snapshots" do
           "#{fixture_name}.sh"
         )
 
-        expect(output).to eq("#{File.read(snapshot_path)}\n")
+        expect_snapshot(output, snapshot_path)
       end
     end
   end
@@ -60,6 +68,6 @@ describe "tmuxinator debug snapshots" do
 
     snapshot_path = File.join(snapshot_root, "2.6", "session_name.sh")
 
-    expect(output).to eq("#{File.read(snapshot_path)}\n")
+    expect_snapshot(output, snapshot_path)
   end
 end


### PR DESCRIPTION
### Problem / Motivation

Interface snapshot updates required ad hoc Ruby commands, so contributors could verify snapshots but not regenerate them through the documented interface test target.

### Solution

- [X] CHANGELOG entry is added for code changes

Teach the interface snapshot spec to rewrite snapshots when `UPDATE_SNAPSHOTS` is set and document the workflow with `bundle exec rake interface`.

### Testing

N/A