### PR TITLE
test: update basic interface snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 ### Misc
+- Update interface snapshots for the basic fixture commands pane
 - Add `UPDATE_SNAPSHOTS` support for regenerating interface snapshots
 - Update Ruby versions tested in CI interface tests
 

--- a/spec/fixtures/interface/basic.yml
+++ b/spec/fixtures/interface/basic.yml
@@ -11,4 +11,6 @@ windows:
   - shell:
       root: .
       panes:
-        - bin/setup
+        - commands:
+            - bin/setup
+            - bundle exec rake test

--- a/spec/snapshots/debug/1.6/basic.sh
+++ b/spec/snapshots/debug/1.6/basic.sh
@@ -52,6 +52,7 @@ cd /workspace/basic
 
   tmux -L interface send-keys -t basic:1.0 bundle\ exec\ ruby\ -v C-m
   tmux -L interface send-keys -t basic:1.0 bin/setup C-m
+  tmux -L interface send-keys -t basic:1.0 bundle\ exec\ rake\ test C-m
 
   tmux -L interface select-layout -t basic:1 tiled
 

--- a/spec/snapshots/debug/1.8/basic.sh
+++ b/spec/snapshots/debug/1.8/basic.sh
@@ -50,6 +50,7 @@ cd /workspace/basic
 
   tmux -L interface send-keys -t basic:1.0 bundle\ exec\ ruby\ -v C-m
   tmux -L interface send-keys -t basic:1.0 bin/setup C-m
+  tmux -L interface send-keys -t basic:1.0 bundle\ exec\ rake\ test C-m
 
   tmux -L interface select-layout -t basic:1 tiled
 

--- a/spec/snapshots/debug/2.6/basic.sh
+++ b/spec/snapshots/debug/2.6/basic.sh
@@ -50,9 +50,10 @@ cd /workspace/basic
   # Window "shell"
 
 
-  
+  tmux -L interface select-pane -t basic:1.0 -T commands
   tmux -L interface send-keys -t basic:1.0 bundle\ exec\ ruby\ -v C-m
   tmux -L interface send-keys -t basic:1.0 bin/setup C-m
+  tmux -L interface send-keys -t basic:1.0 bundle\ exec\ rake\ test C-m
 
   tmux -L interface select-layout -t basic:1 tiled
 


### PR DESCRIPTION
### Metadata

Adds the reproducing template from issue #988 (bug is not reproduced by our tests on Ruby 4)

### Problem / Motivation

The basic interface fixture does not exercise a named commands pane with multiple commands.

### Solution

- [X] CHANGELOG entry is added for code changes

Update the basic fixture snapshots for supported tmux versions and record the snapshot refresh in the changelog.

### Testing

N/A - It's all tests.