### PR TITLE
chore: add support for tmux 3.7b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Update interface snapshots for the basic fixture commands pane
 - Add `UPDATE_SNAPSHOTS` support for regenerating interface snapshots
 - Update Ruby versions tested in CI interface tests
-- Include tmux 3.7 and 3.7a in supported versions list
+- Include tmux 3.7, 3.7a, and 3.7b in supported versions list
 
 ## 3.4.0
 ### Features

--- a/lib/tmuxinator/tmux_version.rb
+++ b/lib/tmuxinator/tmux_version.rb
@@ -3,6 +3,7 @@
 module Tmuxinator
   module TmuxVersion
     SUPPORTED_TMUX_VERSIONS = [
+      "3.7b",
       "3.7a",
       3.7,
       "3.6b",

--- a/spec/lib/tmuxinator/config_spec.rb
+++ b/spec/lib/tmuxinator/config_spec.rb
@@ -208,6 +208,7 @@ describe Tmuxinator::Config do
       "v3.6b" => 3.6,
       "v3.7" => 3.7,
       "v3.7a" => 3.7,
+      "v3.7b" => 3.7,
       "v3.12.0" => 3.12,
       "v3.12.5" => 3.12
     }.freeze


### PR DESCRIPTION
### Metadata

https://github.com/tmux/tmux/releases/tag/3.7b

### Problem / Motivation

tmux 3.7b released.

### Solution

Add tmux 3.7b to supported version list.

### Testing

Updated config_spec.rb

This is a clone of #997 and #1000 - 3.7b was just released ~18hrs ago.
