### PR TITLE
chore: Bump tmuxinator to v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## 3.4.1
 ### Misc
 - Update interface snapshots for the basic fixture commands pane
 - Add `UPDATE_SNAPSHOTS` support for regenerating interface snapshots

--- a/lib/tmuxinator/version.rb
+++ b/lib/tmuxinator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tmuxinator
-  VERSION = "3.4.0"
+  VERSION = "3.4.1"
 end


### PR DESCRIPTION
## 3.4.1
### Misc
- Update interface snapshots for the basic fixture commands pane
- Add `UPDATE_SNAPSHOTS` support for regenerating interface snapshots
- Update Ruby versions tested in CI interface tests
- Include tmux 3.7, 3.7a, and 3.7b in supported versions list
