### PR TITLE
fix: avoid bash-only [[ in current_session_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Fixes
+- Avoid bash-only `[[` when resolving the current session name so `stop_all` works under POSIX `/bin/sh` (e.g. dash on Debian)
 
 ## 3.4.1
 ### Misc

--- a/lib/tmuxinator/util.rb
+++ b/lib/tmuxinator/util.rb
@@ -14,7 +14,9 @@ module Tmuxinator
     end
 
     def current_session_name
-      `[[ -n "${TMUX+set}" ]] && tmux display-message -p "#S"`.strip
+      return "" unless ENV.key?("TMUX")
+
+      `tmux display-message -p "#S"`.strip
     end
   end
 end

--- a/spec/lib/tmuxinator/util_spec.rb
+++ b/spec/lib/tmuxinator/util_spec.rb
@@ -6,34 +6,40 @@ describe Tmuxinator::Util do
   let(:util) { Object.new.extend(Tmuxinator::Util) }
 
   describe "#current_session_name" do
+    def with_env(key, value)
+      had_key = ENV.key?(key)
+      original = ENV[key]
+      if value.nil?
+        ENV.delete(key)
+      else
+        ENV[key] = value
+      end
+      yield
+    ensure
+      if had_key
+        ENV[key] = original
+      else
+        ENV.delete(key)
+      end
+    end
+
     context "when TMUX is not set" do
       it "returns an empty string without invoking the shell" do
-        original = ENV.delete("TMUX")
-        begin
+        with_env("TMUX", nil) do
           expect(util).not_to receive(:`)
           expect(util.current_session_name).to eq("")
-        ensure
-          ENV["TMUX"] = original if original
         end
       end
     end
 
     context "when TMUX is set" do
       it "returns the current tmux session name" do
-        original = ENV["TMUX"]
-        ENV["TMUX"] = "/tmp/tmux-1000/default,1,0"
-        begin
+        with_env("TMUX", "/tmp/tmux-1000/default,1,0") do
           expect(util).to receive(:`).
             with('tmux display-message -p "#S"').
             and_return("flash\n")
 
           expect(util.current_session_name).to eq("flash")
-        ensure
-          if original
-            ENV["TMUX"] = original
-          else
-            ENV.delete("TMUX")
-          end
         end
       end
     end

--- a/spec/lib/tmuxinator/util_spec.rb
+++ b/spec/lib/tmuxinator/util_spec.rb
@@ -4,4 +4,38 @@ require "spec_helper"
 
 describe Tmuxinator::Util do
   let(:util) { Object.new.extend(Tmuxinator::Util) }
+
+  describe "#current_session_name" do
+    context "when TMUX is not set" do
+      it "returns an empty string without invoking the shell" do
+        original = ENV.delete("TMUX")
+        begin
+          expect(util).not_to receive(:`)
+          expect(util.current_session_name).to eq("")
+        ensure
+          ENV["TMUX"] = original if original
+        end
+      end
+    end
+
+    context "when TMUX is set" do
+      it "returns the current tmux session name" do
+        original = ENV["TMUX"]
+        ENV["TMUX"] = "/tmp/tmux-1000/default,1,0"
+        begin
+          expect(util).to receive(:`).
+            with('tmux display-message -p "#S"').
+            and_return("flash\n")
+
+          expect(util.current_session_name).to eq("flash")
+        ensure
+          if original
+            ENV["TMUX"] = original
+          else
+            ENV.delete("TMUX")
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Metadata

Fixes #978

### Problem / Motivation

`tmuxinator stop_all` prints `sh: 1: [[: not found` for each stopped session when `/bin/sh` is dash (Debian, Ubuntu, Linux Mint).

`Util#current_session_name` shells out with bash-only `[[ ... ]]`, and Ruby backticks run under `/bin/sh`.

### Solution

- [x] CHANGELOG entry is added for code changes

Resolve the current session name in Ruby via `ENV.key?("TMUX")` before calling `tmux display-message`, so no shell conditional is required.

### Testing

Added unit coverage for `#current_session_name` with and without `TMUX` set.

Reproduced the original dash error with:

```sh
docker run --rm debian:bookworm-slim sh -c '[[ -n "${TMUX+set}" ]] && echo ok'
# => sh: 1: [[: not found
```
